### PR TITLE
Fix Nuget inspector to parse specific range strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@ detect-nuget-inspector/.vs/
 detect-nuget-inspector/detect-nuget-inspector/bin/
 detect-nuget-inspector/detect-nuget-inspector/linux-build/
 detect-nuget-inspector/detect-nuget-inspector/obj/
+detect-nuget-inspector/detect-nuget-inspector-tests/bin/
+detect-nuget-inspector/detect-nuget-inspector-tests/linux-build/
+detect-nuget-inspector/detect-nuget-inspector-tests/obj/
+
 
 .idea
 *.iml

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Nuget/Resolver/NugetLockFileResolverTest.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Nuget/Resolver/NugetLockFileResolverTest.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget;
-namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget.Test
+﻿namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget.Test
 {
     [TestClass]
     public class NugetLockFileResolverTest

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Nuget/Resolver/NugetLockFileResolverTest.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Nuget/Resolver/NugetLockFileResolverTest.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget;
+namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget.Test
+{
+    [TestClass]
+    public class NugetLockFileResolverTest
+    {
+        [TestMethod]
+        public void ParseProjectFileDependencyGroupTestWithMinInclusiveOnly()
+        {
+            NugetLockFileResolver lockFileResolver = new NugetLockFileResolver(null);
+            var lockFileDependency = "Newtonsoft.Json >= 13.0.1";
+
+            var dependency = lockFileResolver.ParseProjectFileDependencyGroup(lockFileDependency);
+            Assert.IsNotNull(dependency);
+
+        }
+
+        [TestMethod]
+        public void ParseProjectFileDependencyGroupTestWithMinExclusiveOnly()
+        {
+            NugetLockFileResolver lockFileResolver = new NugetLockFileResolver(null);
+            var lockFileDependency = "Newtonsoft.Json > 13.0.1";
+
+            var dependency = lockFileResolver.ParseProjectFileDependencyGroup(lockFileDependency);
+            Assert.IsNotNull(dependency);
+
+        }
+
+        [TestMethod]
+        public void ParseProjectFileDependencyGroupTestWithSameRange()
+        {
+            NugetLockFileResolver lockFileResolver = new NugetLockFileResolver(null);
+            var lockFileDependency = "Newtonsoft.Json >= 13.0.1 <= 13.0.1";
+
+            var dependency = lockFileResolver.ParseProjectFileDependencyGroup(lockFileDependency);
+            Assert.IsNotNull(dependency);
+
+        }
+
+        [TestMethod]
+        public void ParseProjectFileDependencyGroupTestWithMinAndMaxExclusiveRange()
+        {
+            NugetLockFileResolver lockFileResolver = new NugetLockFileResolver(null);
+            var lockFileDependency = "Newtonsoft.Json >= 12.0.1 < 13.0.1";
+
+            var dependency = lockFileResolver.ParseProjectFileDependencyGroup(lockFileDependency);
+            Assert.IsNotNull(dependency);
+
+        }
+
+        [TestMethod]
+        public void ParseProjectFileDependencyGroupTestWithMinExclusiveAndMaxInclusiveRange()
+        {
+            NugetLockFileResolver lockFileResolver = new NugetLockFileResolver(null);
+            var lockFileDependency = "Newtonsoft.Json > 12.0.1 <= 13.0.1";
+
+            var dependency = lockFileResolver.ParseProjectFileDependencyGroup(lockFileDependency);
+            Assert.IsNotNull(dependency);
+
+        }
+
+        [TestMethod]
+        public void ParseProjectFileDependencyGroupTestWithMinExclusiveAndMaxExclusiveRange()
+        {
+            NugetLockFileResolver lockFileResolver = new NugetLockFileResolver(null);
+            var lockFileDependency = "Newtonsoft.Json > 12.0.1 < 13.0.1";
+
+            var dependency = lockFileResolver.ParseProjectFileDependencyGroup(lockFileDependency);
+            Assert.IsNotNull(dependency);
+
+        }
+
+        [TestMethod]
+        public void ParseProjectFileDependencyGroupTestWithMaxInclusiveOnly()
+        {
+            NugetLockFileResolver lockFileResolver = new NugetLockFileResolver(null);
+            var lockFileDependency = "Newtonsoft.Json <= 13.0.1";
+
+            var dependency = lockFileResolver.ParseProjectFileDependencyGroup(lockFileDependency);
+            Assert.IsNotNull(dependency);
+
+        }
+
+        [TestMethod]
+        public void ParseProjectFileDependencyGroupTestWithMaxExclusiveOnly()
+        {
+            NugetLockFileResolver lockFileResolver = new NugetLockFileResolver(null);
+            var lockFileDependency = "Newtonsoft.Json < 13.0.1";
+
+            var dependency = lockFileResolver.ParseProjectFileDependencyGroup(lockFileDependency);
+            Assert.IsNotNull(dependency);
+
+        }
+
+
+    }
+}

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/Usings.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/Usings.cs
@@ -1,0 +1,1 @@
+﻿global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/detect-nuget-inspector-tests.csproj
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/detect-nuget-inspector-tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <RootNamespace>detect_nuget_inspector_tests</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="DependencyResolution\" />
+    <None Remove="DependencyResolution\Nuget\" />
+    <None Remove="DependencyResolution\Nuget\Resolver\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="DependencyResolution\" />
+    <Folder Include="DependencyResolution\Nuget\" />
+    <Folder Include="DependencyResolution\Nuget\Resolver\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\detect-nuget-inspector\detect-nuget-inspector.csproj" />
+  </ItemGroup>
+</Project>

--- a/detect-nuget-inspector/detect-nuget-inspector.sln
+++ b/detect-nuget-inspector/detect-nuget-inspector.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.1.32228.430
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "detect-nuget-inspector", "detect-nuget-inspector\detect-nuget-inspector.csproj", "{11C8B8AB-5476-42CD-961A-4DDCD9C9C0FD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "detect-nuget-inspector-tests", "detect-nuget-inspector-tests\detect-nuget-inspector-tests.csproj", "{9509BDFF-269B-42C6-A9B4-CF19751AB76D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{11C8B8AB-5476-42CD-961A-4DDCD9C9C0FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{11C8B8AB-5476-42CD-961A-4DDCD9C9C0FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{11C8B8AB-5476-42CD-961A-4DDCD9C9C0FD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9509BDFF-269B-42C6-A9B4-CF19751AB76D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9509BDFF-269B-42C6-A9B4-CF19751AB76D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9509BDFF-269B-42C6-A9B4-CF19751AB76D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9509BDFF-269B-42C6-A9B4-CF19751AB76D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/Resolver/NugetLockFileResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/Resolver/NugetLockFileResolver.cs
@@ -218,18 +218,19 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget
             throw new Exception("Unable to parse project file dependency group, please contact support: " + projectFileDependency);
         }
 
-        private bool ParseProjectFileDependencyGroupTokens(string input, string tokens, out String projectName, out String projectVersion)
+        private bool ParseProjectFileDependencyGroupTokens(string input, string tokens, out String prefixString, out String projectVersion)
         {
             if (input.Contains(tokens))
             {
                 String[] pieces = input.Split(tokens);
-                projectName = pieces[0].Trim();
+                // this is often the project name but with some ranges it is the minimum version.
+                prefixString = pieces[0].Trim();
                 projectVersion = pieces[1].Trim();
                 return true;
             }
             else
             {
-                projectName = null;
+                prefixString = null;
                 projectVersion = null;
                 return false;
             }


### PR DESCRIPTION
Created a Unit test project to test the ranges.
When a NuGet dependency is in the project with this version "[13.0.1]" the projectFileDependency string used for parsing is 
"Newtonsoft.Json >= 13.0.1 <= 13.0.1"

The parsing code that existed didn't handle a range like this. Added the ability to handle a range of dependencies.