### PR TITLE
Improved dependency detection from project.json

### DIFF
--- a/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Project/ProjectJsonResolverTests.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Project/ProjectJsonResolverTests.cs
@@ -13,23 +13,6 @@ public class ProjectJsonResolverTests
 
         return jsonFilePath;
     }
-
-    [TestMethod]
-    public void ProcessTestForNewFormat()
-    {
-        string projectName = "ProjectName";
-        string projectJsonPath = GetJsonPath("newFormat_Project.json");
-        ProjectJsonResolver projectJsonResolver = new ProjectJsonResolver(projectName, projectJsonPath);
-        
-        var result = projectJsonResolver.Process();
-        
-        Assert.IsNotNull(result);
-        Assert.IsNotNull(result.Packages);
-        Assert.IsNotNull(result.Dependencies);
-       
-        Assert.AreEqual(5, result.Packages.Count);
-        Assert.AreEqual(5, result.Dependencies.Count);
-    }
     
     [TestMethod]
     public void ExtractPackageSpecDependenciesTestForOldFormat()

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Project/ProjectJsonResolverTests.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Project/ProjectJsonResolverTests.cs
@@ -23,7 +23,6 @@ public class ProjectJsonResolverTests
                 projectJsonResolverForOldFormat);
 
         Assert.IsNotNull(result);
-        Assert.IsTrue(result.ContainsKey("dependencies"));
 
         JObject dependenciesObject = result.GetValue("dependencies") as JObject;
 
@@ -43,7 +42,6 @@ public class ProjectJsonResolverTests
                 projectJsonResolverForNewFormat);
 
         Assert.IsNotNull(result);
-        Assert.IsTrue(result.ContainsKey("dependencies"));
 
         JObject dependenciesObject = result.GetValue("dependencies") as JObject;
 
@@ -79,7 +77,6 @@ public class ProjectJsonResolverTests
         ProjectJsonResolver projectJsonResolver = new ProjectJsonResolver("projectName", fakeJsonPath);
         var result = projectJsonResolver.CreatePackageSpecFromJson("projectName", packageSpecJsonObject);
 
-        Assert.AreEqual("projectName", result.Name.ToString());
         Assert.AreEqual("1.0.0", result.Version.ToString());
         Assert.AreEqual(2, result.Dependencies.Count);
 

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Project/ProjectJsonResolverTests.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Project/ProjectJsonResolverTests.cs
@@ -1,0 +1,79 @@
+using Newtonsoft.Json.Linq;
+using Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project;
+
+namespace detect_nuget_inspector_tests.DependencyResolution.Project;
+
+[TestClass]
+public class ProjectJsonResolverTests
+{
+    public string GetJsonPath(string jsonFileName)
+    {
+        string projectDirectory = Directory.GetParent(Environment.CurrentDirectory).Parent.Parent.FullName;
+        string jsonFilePath = Path.Combine(projectDirectory, "Files", jsonFileName);
+
+        return jsonFilePath;
+    }
+
+    [TestMethod]
+    public void ProcessTestForNewFormat()
+    {
+        string projectName = "ProjectName";
+        string projectJsonPath = GetJsonPath("newFormat_Project.json");
+        ProjectJsonResolver projectJsonResolver = new ProjectJsonResolver(projectName, projectJsonPath);
+        
+        var result = projectJsonResolver.Process();
+        
+        Assert.IsNotNull(result);
+        Assert.IsNotNull(result.Packages);
+        Assert.IsNotNull(result.Dependencies);
+       
+        Assert.AreEqual(5, result.Packages.Count);
+        Assert.AreEqual(5, result.Dependencies.Count);
+    }
+    
+    [TestMethod]
+    public void ExtractPackageSpecDependenciesTestForOldFormat()
+    {
+        string projectJsonPath = GetJsonPath("oldFormat_Project.json");
+        var projectJsonResolverForOldFormat = new ProjectJsonResolver("ProjectName", projectJsonPath);
+        JObject result = projectJsonResolverForOldFormat.ExtractPackageSpecDependencies(projectJsonPath, projectJsonResolverForOldFormat);
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.ContainsKey("dependencies"));
+
+        JObject dependenciesObject = result.GetValue("dependencies") as JObject;
+        
+        Assert.IsNotNull(dependenciesObject);
+        Assert.AreEqual(8, dependenciesObject.Count);
+        Assert.AreEqual("4.0.1", dependenciesObject.GetValue("System.Xml.XmlDocument").ToString());
+        Assert.AreEqual("4.1.0", dependenciesObject.GetValue("System.AppContext").ToString());
+    }
+    
+    [TestMethod]
+    public void ExtractPackageSpecDependenciesTestForNewFormat()
+    {
+        string projectJsonPath = GetJsonPath("newFormat_Project.json");
+        var projectJsonResolverForNewFormat = new ProjectJsonResolver("ProjectName", projectJsonPath);
+        JObject result = projectJsonResolverForNewFormat.ExtractPackageSpecDependencies(projectJsonPath, projectJsonResolverForNewFormat);
+        
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.ContainsKey("dependencies"));
+
+        JObject dependenciesObject = result.GetValue("dependencies") as JObject;
+     
+        Assert.IsNotNull(dependenciesObject);
+        Assert.AreEqual(5, dependenciesObject.Count);
+        Assert.AreEqual("1.0.0", dependenciesObject.GetValue("Microsoft.AspNetCore.Server.IISIntegration").ToString());
+        Assert.AreEqual("4.1.0", dependenciesObject.GetValue("System.AppContext").ToString());
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(NullReferenceException))]
+    public void ExtractPackageSpecDependenciesTestWhenDependenciesNotFound()
+    {
+        string projectJsonPath = GetJsonPath("withoutDependencies_Project.json");
+        var projectJsonResolver = new ProjectJsonResolver("ProjectName", projectJsonPath);
+
+        projectJsonResolver.ExtractPackageSpecDependencies(projectJsonPath, projectJsonResolver);
+    }
+}

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Project/ProjectJsonResolverTests.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Project/ProjectJsonResolverTests.cs
@@ -1,8 +1,6 @@
-using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
 using Newtonsoft.Json.Linq;
-using Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project;
 
-namespace detect_nuget_inspector_tests.DependencyResolution.Project;
+namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project.Test;
 
 [TestClass]
 public class ProjectJsonResolverTests
@@ -14,7 +12,7 @@ public class ProjectJsonResolverTests
 
         return jsonFilePath;
     }
-    
+
     [TestMethod]
     public void ExtractPackageSpecDependenciesTestForOldFormat()
     {
@@ -64,6 +62,7 @@ public class ProjectJsonResolverTests
 
         projectJsonResolver.ExtractPackageSpecDependencies(projectJsonPath, projectJsonResolver);
     }
+
     [TestMethod]
     public void CreatePackageSpecFromJsonTest()
     {
@@ -73,21 +72,22 @@ public class ProjectJsonResolverTests
                     ""Dependency2"": ""4.5.6""
                   }
         }");
-        
+
         string fakeJsonPath = GetJsonPath("fake.json");
         File.WriteAllText(fakeJsonPath, "{}");
-        
+
         ProjectJsonResolver projectJsonResolver = new ProjectJsonResolver("projectName", fakeJsonPath);
         var result = projectJsonResolver.CreatePackageSpecFromJson("projectName", packageSpecJsonObject);
-        
+
         Assert.AreEqual("projectName", result.Name.ToString());
         Assert.AreEqual("1.0.0", result.Version.ToString());
         Assert.AreEqual(2, result.Dependencies.Count);
-       
+
         Assert.IsTrue(result.Dependencies.Any(dependency => dependency.Name == "Dependency2"));
-        
-        File.Delete(fakeJsonPath); 
+
+        File.Delete(fakeJsonPath);
     }
+
     [TestMethod]
     public void ProcessTestForNewFormat()
     {
@@ -103,8 +103,9 @@ public class ProjectJsonResolverTests
 
         Assert.AreEqual(5, result.Packages.Count);
         Assert.AreEqual(5, result.Dependencies.Count);
-        
-        CollectionAssert.Contains(result.Dependencies.Select(dep => dep.Name).ToList(), "Microsoft.AspNetCore.Server.Kestrel");
+
+        CollectionAssert.Contains(result.Dependencies.Select(dep => dep.Name).ToList(),
+            "Microsoft.AspNetCore.Server.Kestrel");
     }
 
     [TestMethod]
@@ -122,10 +123,11 @@ public class ProjectJsonResolverTests
 
         Assert.AreEqual(8, result.Packages.Count);
         Assert.AreEqual(8, result.Dependencies.Count);
-        
-        CollectionAssert.Contains(result.Dependencies.Select(dep => dep.Name).ToList(), "System.Collections.NonGeneric");
+
+        CollectionAssert.Contains(result.Dependencies.Select(dep => dep.Name).ToList(),
+            "System.Collections.NonGeneric");
     }
-    
+
     [TestMethod]
     [ExpectedException(typeof(NullReferenceException))]
     public void ProcessTestWhenDependenciesNotFound()

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Project/ProjectJsonResolverTests.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Project/ProjectJsonResolverTests.cs
@@ -19,31 +19,35 @@ public class ProjectJsonResolverTests
     {
         string projectJsonPath = GetJsonPath("oldFormat_Project.json");
         var projectJsonResolverForOldFormat = new ProjectJsonResolver("ProjectName", projectJsonPath);
-        JObject result = projectJsonResolverForOldFormat.ExtractPackageSpecDependencies(projectJsonPath, projectJsonResolverForOldFormat);
+        JObject result =
+            projectJsonResolverForOldFormat.ExtractPackageSpecDependencies(projectJsonPath,
+                projectJsonResolverForOldFormat);
 
         Assert.IsNotNull(result);
         Assert.IsTrue(result.ContainsKey("dependencies"));
 
         JObject dependenciesObject = result.GetValue("dependencies") as JObject;
-        
+
         Assert.IsNotNull(dependenciesObject);
         Assert.AreEqual(8, dependenciesObject.Count);
         Assert.AreEqual("4.0.1", dependenciesObject.GetValue("System.Xml.XmlDocument").ToString());
         Assert.AreEqual("4.1.0", dependenciesObject.GetValue("System.AppContext").ToString());
     }
-    
+
     [TestMethod]
     public void ExtractPackageSpecDependenciesTestForNewFormat()
     {
         string projectJsonPath = GetJsonPath("newFormat_Project.json");
         var projectJsonResolverForNewFormat = new ProjectJsonResolver("ProjectName", projectJsonPath);
-        JObject result = projectJsonResolverForNewFormat.ExtractPackageSpecDependencies(projectJsonPath, projectJsonResolverForNewFormat);
-        
+        JObject result =
+            projectJsonResolverForNewFormat.ExtractPackageSpecDependencies(projectJsonPath,
+                projectJsonResolverForNewFormat);
+
         Assert.IsNotNull(result);
         Assert.IsTrue(result.ContainsKey("dependencies"));
 
         JObject dependenciesObject = result.GetValue("dependencies") as JObject;
-     
+
         Assert.IsNotNull(dependenciesObject);
         Assert.AreEqual(5, dependenciesObject.Count);
         Assert.AreEqual("1.0.0", dependenciesObject.GetValue("Microsoft.AspNetCore.Server.IISIntegration").ToString());
@@ -58,5 +62,54 @@ public class ProjectJsonResolverTests
         var projectJsonResolver = new ProjectJsonResolver("ProjectName", projectJsonPath);
 
         projectJsonResolver.ExtractPackageSpecDependencies(projectJsonPath, projectJsonResolver);
+    }
+
+    [TestMethod]
+    public void ProcessTestForNewFormat()
+    {
+        string projectName = "ProjectName";
+        string projectJsonPath = GetJsonPath("newFormat_Project.json");
+        ProjectJsonResolver projectJsonResolver = new ProjectJsonResolver(projectName, projectJsonPath);
+
+        var result = projectJsonResolver.Process();
+
+        Assert.IsNotNull(result);
+        Assert.IsNotNull(result.Packages);
+        Assert.IsNotNull(result.Dependencies);
+
+        Assert.AreEqual(5, result.Packages.Count);
+        Assert.AreEqual(5, result.Dependencies.Count);
+        
+        CollectionAssert.Contains(result.Dependencies.Select(dep => dep.Name).ToList(), "Microsoft.AspNetCore.Server.Kestrel");
+    }
+
+    [TestMethod]
+    public void ProcessTestForOldFormat()
+    {
+        string projectName = "ProjectName";
+        string projectJsonPath = GetJsonPath("oldFormat_Project.json");
+        ProjectJsonResolver projectJsonResolver = new ProjectJsonResolver(projectName, projectJsonPath);
+
+        var result = projectJsonResolver.Process();
+
+        Assert.IsNotNull(result);
+        Assert.IsNotNull(result.Packages);
+        Assert.IsNotNull(result.Dependencies);
+
+        Assert.AreEqual(8, result.Packages.Count);
+        Assert.AreEqual(8, result.Dependencies.Count);
+        
+        CollectionAssert.Contains(result.Dependencies.Select(dep => dep.Name).ToList(), "System.Collections.NonGeneric");
+    }
+    
+    [TestMethod]
+    [ExpectedException(typeof(NullReferenceException))]
+    public void ProcessTestWhenDependenciesNotFound()
+    {
+        string projectName = "ProjectName";
+        string projectJsonPath = GetJsonPath("withoutDependencies_Project.json");
+        ProjectJsonResolver projectJsonResolver = new ProjectJsonResolver(projectName, projectJsonPath);
+
+        var result = projectJsonResolver.Process();
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Project/ProjectJsonResolverTests.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Project/ProjectJsonResolverTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
 using Newtonsoft.Json.Linq;
 using Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project;
 
@@ -63,7 +64,30 @@ public class ProjectJsonResolverTests
 
         projectJsonResolver.ExtractPackageSpecDependencies(projectJsonPath, projectJsonResolver);
     }
-
+    [TestMethod]
+    public void CreatePackageSpecFromJsonTest()
+    {
+        JObject packageSpecJsonObject = JObject.Parse(@"{
+                ""dependencies"": {
+                    ""Dependency1"": ""1.2.3"",
+                    ""Dependency2"": ""4.5.6""
+                  }
+        }");
+        
+        string fakeJsonPath = GetJsonPath("fake.json");
+        File.WriteAllText(fakeJsonPath, "{}");
+        
+        ProjectJsonResolver projectJsonResolver = new ProjectJsonResolver("projectName", fakeJsonPath);
+        var result = projectJsonResolver.CreatePackageSpecFromJson("projectName", packageSpecJsonObject);
+        
+        Assert.AreEqual("projectName", result.Name.ToString());
+        Assert.AreEqual("1.0.0", result.Version.ToString());
+        Assert.AreEqual(2, result.Dependencies.Count);
+       
+        Assert.IsTrue(result.Dependencies.Any(dependency => dependency.Name == "Dependency2"));
+        
+        File.Delete(fakeJsonPath); 
+    }
     [TestMethod]
     public void ProcessTestForNewFormat()
     {

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/Files/newFormat_Project.json
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/Files/newFormat_Project.json
@@ -1,0 +1,36 @@
+{
+  "dependencies": {
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
+    "Microsoft.Extensions.Logging.Console": "1.0.0",
+    "System.AppContext": "4.1.0"
+  },
+  "tools": {
+    "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.0.0-preview2-final"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [
+        "dotnet5.6",
+        "portable-net45+win8"
+      ]
+    }
+  },
+  "buildOptions": {
+    "emitEntryPoint": true,
+    "preserveCompilationContext": true
+  },
+  "runtimeOptions": {
+    "configProperties": {
+      "System.GC.Server": true
+    }
+  },
+  "publishOptions": {
+    "include": [
+      "wwwroot",
+      "web.config"
+    ]
+  },
+  "scripts": {}
+}

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/Files/oldFormat_Project.json
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/Files/oldFormat_Project.json
@@ -1,0 +1,38 @@
+{
+  "name": "log4net",
+  "version": "2.0.8",
+  "title": "Apache log4net for .NET Core",
+  "copyright": "Copyright 2004-2017 The Apache Software Foundation.",
+  "frameworks": {
+    "netstandard1.3": {
+      "buildOptions": {
+        "compile": {
+          "include": [
+            "*.cs",
+            "../../src/**/*.cs"
+          ],
+          "exclude": [
+            "../../src/Appender/AdoNetAppender.cs",
+            "../../src/Appender/AspNetTraceAppender.cs",
+            "../../src/Appender/ColoredConsoleAppender.cs"
+          ]
+        },
+        "define": [
+          "HAS_READERWRITERLOCKSLIM"
+        ],
+        "publicSign": true,
+        "keyFile": "../../log4net.snk"
+      },
+      "dependencies": {
+        "System.AppContext": "4.1.0",
+        "System.Collections.NonGeneric": "4.0.1",
+        "System.Console": "4.0.0",
+        "System.Threading": "4.0.11",
+        "System.Threading.Thread": "4.0.0",
+        "System.Threading.Timer": "4.0.1",
+        "System.Xml.ReaderWriter": "4.0.11",
+        "System.Xml.XmlDocument": "4.0.1"
+      }
+    }
+  }
+}

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/Files/withoutDependencies_Project.json
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/Files/withoutDependencies_Project.json
@@ -1,0 +1,29 @@
+{
+  "tools": {
+    "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.0.0-preview2-final"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [
+        "dotnet5.6",
+        "portable-net45+win8"
+      ]
+    }
+  },
+  "buildOptions": {
+    "emitEntryPoint": true,
+    "preserveCompilationContext": true
+  },
+  "runtimeOptions": {
+    "configProperties": {
+      "System.GC.Server": true
+    }
+  },
+  "publishOptions": {
+    "include": [
+      "wwwroot",
+      "web.config"
+    ]
+  },
+  "scripts": {}
+}

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectJsonResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectJsonResolver.cs
@@ -59,6 +59,7 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
         public PackageSpec CreatePackageSpecFromJson(string projectName, JObject packageSpecJsonObject)
         {
             string tempFilePath = Path.GetTempFileName();
+            
             File.WriteAllText(tempFilePath, packageSpecJsonObject.ToString());
 
             PackageSpec packageSpec = JsonPackageSpecReader.GetPackageSpec(projectName, tempFilePath);
@@ -86,7 +87,7 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
                     }
                 }
             }
-
+            
             return null;
         }
     }

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectJsonResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectJsonResolver.cs
@@ -87,7 +87,6 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
                     }
                 }
             }
-            
             return null;
         }
     }

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectJsonResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectJsonResolver.cs
@@ -4,7 +4,7 @@ using NuGet.ProjectModel;
 
 namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
 {
-    class ProjectJsonResolver : DependencyResolver
+    public class ProjectJsonResolver : DependencyResolver
     {
         private string ProjectName;
         private string ProjectJsonPath;

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectJsonResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectJsonResolver.cs
@@ -39,14 +39,21 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
         public JObject ExtractPackageSpecDependencies(string projectJsonPath, ProjectJsonResolver projectJsonResolver)
         {
             const string TargetKey = "dependencies";
+            JObject packageSpecDependencies = new JObject();
+            
             JObject jsonObject = JObject.Parse(File.ReadAllText(projectJsonPath));
 
             JObject dependenciesObject = projectJsonResolver.FindDependencies(jsonObject, TargetKey);
-
-            JObject packageSpecDependencies = new JObject();
-            packageSpecDependencies.Add(TargetKey, dependenciesObject);
-
-            return packageSpecDependencies;
+            
+            if (dependenciesObject is null)
+            {
+                throw new NullReferenceException($"In project.json file, '{TargetKey}' object is  not found.");
+            }
+            else
+            {
+                packageSpecDependencies.Add(TargetKey, dependenciesObject);
+                return packageSpecDependencies;
+            }
         }
 
         public PackageSpec CreatePackageSpecFromJson(string projectName, JObject packageSpecJsonObject)

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectJsonResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectJsonResolver.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Newtonsoft.Json.Linq;
+using NuGet.LibraryModel;
+using NuGet.ProjectModel;
 
 namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
 {
@@ -19,19 +17,70 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
 
         public DependencyResult Process()
         {
+            ProjectJsonResolver projectJsonResolver = new ProjectJsonResolver(ProjectName, ProjectJsonPath);
             var result = new DependencyResult();
 
-            NuGet.ProjectModel.PackageSpec model = NuGet.ProjectModel.JsonPackageSpecReader.GetPackageSpec(ProjectName, ProjectJsonPath);
-            IList<NuGet.LibraryModel.LibraryDependency> packages = model.Dependencies;
+            JObject packageSpecDependencies = projectJsonResolver.ExtractPackageSpecDependencies(ProjectJsonPath, projectJsonResolver);
+            PackageSpec packageSpec = projectJsonResolver.CreatePackageSpecFromJson(ProjectName, packageSpecDependencies);
 
-            foreach (NuGet.LibraryModel.LibraryDependency package in packages)
+            IList<LibraryDependency> packages = packageSpec.Dependencies;
+
+            foreach (LibraryDependency package in packages)
             {
                 var set = new Model.PackageSet();
                 set.PackageId = new Model.PackageId(package.Name, package.LibraryRange.VersionRange.OriginalString);
                 result.Packages.Add(set);
                 result.Dependencies.Add(set.PackageId);
             }
+
             return result;
+        }
+
+        public JObject ExtractPackageSpecDependencies(string projectJsonPath, ProjectJsonResolver projectJsonResolver)
+        {
+            const string TargetKey = "dependencies";
+            JObject jsonObject = JObject.Parse(File.ReadAllText(projectJsonPath));
+
+            JObject dependenciesObject = projectJsonResolver.FindDependencies(jsonObject, TargetKey);
+
+            JObject packageSpecDependencies = new JObject();
+            packageSpecDependencies.Add(TargetKey, dependenciesObject);
+
+            return packageSpecDependencies;
+        }
+
+        public PackageSpec CreatePackageSpecFromJson(string projectName, JObject packageSpecJsonObject)
+        {
+            string tempFilePath = Path.GetTempFileName();
+            File.WriteAllText(tempFilePath, packageSpecJsonObject.ToString());
+
+            PackageSpec packageSpec = JsonPackageSpecReader.GetPackageSpec(projectName, tempFilePath);
+
+            File.Delete(tempFilePath);
+
+            return packageSpec;
+        }
+        
+        public JObject FindDependencies(JObject jsonObject, string targetKey)
+        {
+            foreach (var property in jsonObject.Properties())
+            {
+                if (property.Name.Equals(targetKey, StringComparison.OrdinalIgnoreCase) && property.Value is JObject)
+                {
+                    return (JObject)property.Value;
+                }
+
+                if (property.Value is JObject nestedObject)
+                {
+                    var result = FindDependencies(nestedObject, targetKey);
+                    if (result != null)
+                    {
+                        return result;
+                    }
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectJsonResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectJsonResolver.cs
@@ -32,7 +32,6 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
                 result.Packages.Add(set);
                 result.Dependencies.Add(set.PackageId);
             }
-
             return result;
         }
 


### PR DESCRIPTION
**Ticket**
IDETECT-3820

**Issue Description:**
The transition from the old `project.json` format to the new format introduced compatibility issues, as the application is designed to parse and derive dependencies from the new JSON structure, so it was unable to process projects using the old format. This resulted in a lack of results when dealing with projects in the old format.


**Old `project.json` format:** 
```
{
    "name": "name",
    ....
    "frameworks": {
        "netstandard1.3": {
            "buildOptions": {...
            },
            ..,
            "dependencies": {
                "System.AppContext": "4.1.0",
                "System.Collections.NonGeneric": "4.0.1"
            }
        }
    }
}
```

**New `project.json` format since nuget 3.X+:** 
```
{
    "dependencies": {
        "System.AppContext": "4.1.0",
        "System.Collections.NonGeneric": "4.0.1"
    },
    "frameworks": {
        "TxM": {}
    },
    "runtimes": {
        "RID": {}
    },
    "supports": {
        "CompatibilityProfile": {}
    }
}
```

**Current Approach:**
The current approach only considers the new format of the `project.json` file. To handle variations in the file structure, including the possibility of an older format, enhancement is required to support both the old and new formats.


**My approach:**
To address the compatibility issue between the old and new `project.json` formats, a new solution is implemented that recursively searches for the **"dependencies"** key in the JSON file. The solution ensures compatibility with projects using either format for deriving dependencies.

Recursive searching approach for the key **"dependencies"** arises due to the varying structure of `project.json` files in different formats. In the old format, the **"dependencies"** key is nested within couple of other sections, while in the new format, it is at the top level. To handle projects that may use either format, it was necessary to traverse the JSON structure and locate the **"dependencies"** object within the `project.json` file.

The above approach ensures that it thoroughly examines all possible variations of the `project.json` file, regardless of the structure or nesting levels. This flexibility allows it to handle different versions or formats of the file and retrieve the necessary dependency information reliably.


**Why do we need new approach?**
There could be multiple variations of `project.json` file, each with a different structure. In such cases, a recursive search becomes necessary to explore all possible paths and retrieve the required information.


**Note:**
`project.json` is deprecated since NuGet 4.0+. Nuget team already moved to `PackageReference`.


**Reference:**
https://learn.microsoft.com/en-us/nuget/archive/project-json