### PR TITLE
removed unresolved dependencies.

### DIFF
--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/Resolver/NugetLockFileResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/Resolver/NugetLockFileResolver.cs
@@ -1,14 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget
+﻿namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget
 {
     public class NugetLockFileResolver
     {
         private NuGet.ProjectModel.LockFile LockFile;
+        
+        private static Dictionary<string, string> directDependenciesMap = new Dictionary<string, string>();
+
 
         public NugetLockFileResolver(NuGet.ProjectModel.LockFile lockFile)
         {
@@ -88,18 +85,18 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget
                     {
                         var id = dep.Id;
                         var vr = dep.VersionRange;
-                        //vr.Float.FloatBehavior = NuGet.Versioning.NuGetVersionFloatBehavior.
                         var lb = target.Libraries;
+                        
                         var bs = BestVersion(id, vr, lb);
-                        if (bs == null)
-                        {
-                            Console.WriteLine(dep.Id);
-                            bs = BestVersion(id, vr, lb);
-                        }
-                        else
+                       
+                        if (bs != null)
                         {
                             var depId = new Model.PackageId(id, bs.ToNormalizedString());
                             dependencies.Add(depId);
+                        }
+                        else
+                        {
+                            Console.WriteLine($"WARNING: Unable to resolve a version for the dependency {id}");
                         }
 
                     }
@@ -116,7 +113,19 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget
                 foreach (var dep in LockFile.PackageSpec.Dependencies)
                 {
                     var version = builder.GetBestVersion(dep.Name, dep.LibraryRange.VersionRange);
-                    result.Dependencies.Add(new Model.PackageId(dep.Name, version));
+                    if (version != null)
+                    {
+                        if (!directDependenciesMap.ContainsKey(dep.Name.ToLower()))
+                        {
+                            directDependenciesMap.Add(dep.Name.ToLower(),version);
+                        }
+                        
+                        result.Dependencies.Add(new Model.PackageId(dep.Name, version));
+                    }
+                    else
+                    {
+                        Console.WriteLine($"WARNING: Unable to resolve a version for the dependency {dep.Name}");
+                    }
                 }
             }
             else
@@ -126,7 +135,20 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget
                     foreach (var dep in framework.Dependencies)
                     {
                         var version = builder.GetBestVersion(dep.Name, dep.LibraryRange.VersionRange);
-                        result.Dependencies.Add(new Model.PackageId(dep.Name, version));
+                        
+                        if (version != null)
+                        {
+                            if (!directDependenciesMap.ContainsKey(dep.Name.ToLower()))
+                            {
+                                directDependenciesMap.Add(dep.Name.ToLower(),version);
+                            }
+                          
+                            result.Dependencies.Add(new Model.PackageId(dep.Name, version));
+                        }
+                        else
+                        {
+                            Console.WriteLine($"WARNING: Unable to resolve a version for the dependency {dep.Name}");
+                        }
                     }
                 }
             }
@@ -136,12 +158,19 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget
                 foreach (var projectFileDependency in projectFileDependencyGroup.Dependencies)
                 {
                     var projectDependencyParsed = ParseProjectFileDependencyGroup(projectFileDependency);
-                    var libraryVersion = BestLibraryVersion(projectDependencyParsed.GetName(), projectDependencyParsed.GetVersionRange(), LockFile.Libraries);
+                    var libraryVersion = BestLibraryVersion(projectDependencyParsed.GetName(),
+                        projectDependencyParsed.GetVersionRange(), LockFile.Libraries);
                     String version = null;
                     if (libraryVersion != null)
                     {
                         version = libraryVersion.ToNormalizedString();
                     }
+
+                    if (!directDependenciesMap.ContainsKey(projectDependencyParsed.GetName().ToLower()))
+                    {
+                        directDependenciesMap.Add(projectDependencyParsed.GetName().ToLower(),version);
+                    }
+                    
                     result.Dependencies.Add(new Model.PackageId(projectDependencyParsed.GetName(), version));
                 }
             }
@@ -153,6 +182,30 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget
             }
 
             result.Packages = builder.GetPackageList();
+
+            return  FilterUnresolvedDependencies(result);
+        }
+        
+        
+        public DependencyResult FilterUnresolvedDependencies(DependencyResult result)
+        {
+            result.Packages.RemoveAll(packageSet =>
+            {
+                return packageSet.PackageId != null
+                       && directDependenciesMap.ContainsKey(packageSet.PackageId.Name.ToLower())
+                       && !packageSet.PackageId.Version.Equals(directDependenciesMap[packageSet.PackageId.Name.ToLower()]);
+            });
+
+            result.Packages.ForEach(packageSet =>
+            {
+                packageSet.Dependencies.RemoveWhere(packageId =>
+                {
+                    return packageId != null
+                           && directDependenciesMap.ContainsKey(packageId.Name.ToLower())
+                           && !packageId.Version.Equals(directDependenciesMap[packageId.Name.ToLower()]);
+                });
+            });
+
             return result;
         }
 


### PR DESCRIPTION
Let's say I have an application with the following directory structure:

```
App/
├── Project1/
│   └── Project1.csproj
└── Project2/
    └── Project2.csproj
```

- **Project1** (Project1.csproj) has a direct dependency called `DirectDependencyOne` with a version requirement of **v12**.

- **Project2** (Project2.csproj) has a direct dependency called `DirectDependencyTwo`, which has a transitive dependency on `DirectDependencyOne` with a version requirement of **>= v9**.



When resolving the dependencies, NuGet follows a set of resolution rules, and one of the rules is that the direct dependency always wins. This means that if there are conflicting versions of a package, NuGet will choose the version specified in the direct dependency.



In this case, since **Project1** has a direct dependency on `DirectDependencyOne v12`, that version will be chosen as the resolved version for `DirectDependencyOne` throughout the solution. The transitive dependency from **Project2** on `DirectDependencyOne` will be discarded because the direct dependency takes precedence.



**Note: Unresolved dependencies, as well as their associated transitive dependencies, will be excluded from the resulting set and ultimately from the Bill of Materials (BOM). In other words, any dependencies that cannot be resolved due to conflicts or missing versions will not be included in the final set of dependencies and will not be included in the generated BOM file.**


**Reference**:
https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution#direct-dependency-wins
