### PR TITLE
IDETECT-3626: Add support for resolving dependency versions across subprojects of a solution for project.assets.json files.

### DIFF
--- a/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Nuget/Resolver/NugetLockFileResolverTest.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Nuget/Resolver/NugetLockFileResolverTest.cs
@@ -91,13 +91,6 @@
 
         }
 
-        [TestMethod]
-        public void TestDirectTransitiveVersionRule()
-        {
-            // get csproj with direct and transitive dependency version conflict from test resource file .. 
-            
-            // what we want to unit test is the dependencyMap?????
-        }
 
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Nuget/Resolver/NugetLockFileResolverTest.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Nuget/Resolver/NugetLockFileResolverTest.cs
@@ -91,6 +91,13 @@
 
         }
 
+        [TestMethod]
+        public void TestDirectTransitiveVersionRule()
+        {
+            // get csproj with direct and transitive dependency version conflict from test resource file .. 
+            
+            // what we want to unit test is the dependencyMap?????
+        }
 
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/Resolver/NugetLockFileResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/Resolver/NugetLockFileResolver.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+// testing
 
 namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget
 {


### PR DESCRIPTION
Let's say I have an application with the following directory structure:

```
App/
├── Project1/
│   └── Project1.csproj
└── Project2/
    └── Project2.csproj
```

- **Project1** (Project1.csproj) has a direct dependency called `DirectDependencyOne` with a version requirement of **v12**.

- **Project2** (Project2.csproj) has a direct dependency called `DirectDependencyTwo`, which has a transitive dependency on `DirectDependencyOne` with a version requirement of **>= v9**.



When resolving the dependencies, NuGet follows a set of resolution rules, and one of the rules is that the direct dependency always wins. This means that if there are conflicting versions of a package, NuGet will choose the version specified in the direct dependency.



In this case, since **Project1** has a direct dependency on `DirectDependencyOne v12`, that version will be chosen as the resolved version for `DirectDependencyOne` throughout the solution. The transitive dependency from **Project2** on `DirectDependencyOne` will be discarded because the direct dependency takes precedence.



**Note: Unresolved dependencies, as well as their associated transitive dependencies, will be excluded from the resulting set and ultimately from the Bill of Materials (BOM). In other words, any dependencies that cannot be resolved due to conflicts or missing versions will not be included in the final set of dependencies and will not be included in the generated BOM file.**


**Reference**:
https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution#direct-dependency-wins