### PR TITLE
(fix) Solution/Project Inspection: Prevent NPE when modeule is excluded (IDETECT-4053)

### DIFF
--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
@@ -145,7 +145,10 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                                 {
                                     foreach (Container container in projectResult.Containers)
                                     {
-                                        container.Dependencies.AddRange(packages);
+                                        if (container != null && container.Dependencies != null)
+                                        {
+                                            container.Dependencies.AddRange(packages);
+                                        }
                                     }
                                 }
                                 solution.Children.AddRange(projectResult.Containers);


### PR DESCRIPTION
This change will now check that Project Inspection Result 'container' is not null before attempting to add any packages found during .props file processing to its dependencies list.


