### PR TITLE
Fix for IDETECT-4062

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 ext.dotNetExec = project.hasProperty('dotNetExec') ? project.getProperty('dotNetExec') : 'dotnet6'
 
 group 'com.synopsys.integration'
-version = '1.1.1-SNAPSHOT'
+version = '1.1.0-SNAPSHOT'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'distribution'

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 ext.dotNetExec = project.hasProperty('dotNetExec') ? project.getProperty('dotNetExec') : 'dotnet6'
 
 group 'com.synopsys.integration'
-version = '1.1.0-SNAPSHOT'
+version = '1.1.1-SNAPSHOT'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'distribution'

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
@@ -203,11 +203,13 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                     }
                 }
 
-                Options.ProjectAssetsJsonPath = GetProjectAssetsJsonPathFromNugetProperty(Options.ProjectDirectory, Options.ProjectName, Options.ProjectAssetsJsonPath);
-                if (!String.IsNullOrWhiteSpace(Options.ProjectAssetsJsonPath) && File.Exists(Options.ProjectAssetsJsonPath))
+                var projectAssetsJsonPathFromProperty = GetProjectAssetsJsonPathFromNugetProperty(Options.ProjectDirectory, Options.ProjectName);
+                if (!String.IsNullOrWhiteSpace(projectAssetsJsonPathFromProperty)
+                    && !String.Equals(projectAssetsJsonPathFromProperty, Options.ProjectAssetsJsonPath)
+                    && File.Exists(projectAssetsJsonPathFromProperty))
                 {
-                    Console.WriteLine("Using assets json file configured in property file: " + Options.ProjectAssetsJsonPath);
-                    var projectAssetsJsonResolver = new ProjectAssetsJsonResolver(Options.ProjectAssetsJsonPath);
+                    Console.WriteLine("Using assets json file configured in property file: " + projectAssetsJsonPathFromProperty);
+                    var projectAssetsJsonResolver = new ProjectAssetsJsonResolver(projectAssetsJsonPathFromProperty);
                     var projectAssetsJsonResult = projectAssetsJsonResolver.Process();
                     projectNode.Packages.AddRange(projectAssetsJsonResult.Packages);
                     projectNode.Dependencies.AddRange(projectAssetsJsonResult.Dependencies);
@@ -346,7 +348,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
             return PathUtil.Combine(projectDirectory, "obj", projectName + ".csproj.nuget.g.props");
         }
 
-        private string GetProjectAssetsJsonPathFromNugetProperty(string projectDirectory, string projectName, string projectAssetsJsonPath)
+        private string GetProjectAssetsJsonPathFromNugetProperty(string projectDirectory, string projectName)
         {
             string projectNugetgPropertyPath = CreateProjectNugetgPropertyPath(projectDirectory, projectName);
             bool projectNugetgPropertyExists = !String.IsNullOrWhiteSpace(projectNugetgPropertyPath) && File.Exists(projectNugetgPropertyPath);
@@ -354,9 +356,9 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
             {
                 Console.WriteLine("Using project nuget property file: " + projectNugetgPropertyPath);
                 var xmlResolver = new ProjectNugetgPropertyLoader(projectNugetgPropertyPath, NugetService);
-                projectAssetsJsonPath = xmlResolver.Process();
+                return xmlResolver.Process();
             }
-            return projectAssetsJsonPath;
+            return null;
         }
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
@@ -56,7 +56,6 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                 Options.ProjectName = Path.GetFileNameWithoutExtension(Options.TargetPath);
             }
 
-            Options.ProjectAssetsJsonPath = GetProjectAssetsJsonPathFromNugetProperty(Options.ProjectDirectory, Options.ProjectName, Options.ProjectAssetsJsonPath);
             if (String.IsNullOrWhiteSpace(Options.ProjectAssetsJsonPath))
             {
                 Options.ProjectAssetsJsonPath = CreateProjectAssetsJsonPath(Options.ProjectDirectory);
@@ -202,6 +201,16 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                         projectNode.Packages = xmlResult.Packages;
                         projectNode.Dependencies = xmlResult.Dependencies;
                     }
+                }
+
+                Options.ProjectAssetsJsonPath = GetProjectAssetsJsonPathFromNugetProperty(Options.ProjectDirectory, Options.ProjectName, Options.ProjectAssetsJsonPath);
+                if (!String.IsNullOrWhiteSpace(Options.ProjectAssetsJsonPath) && File.Exists(Options.ProjectAssetsJsonPath))
+                {
+                    Console.WriteLine("Using assets json file configured in property file: " + Options.ProjectAssetsJsonPath);
+                    var projectAssetsJsonResolver = new ProjectAssetsJsonResolver(Options.ProjectAssetsJsonPath);
+                    var projectAssetsJsonResult = projectAssetsJsonResolver.Process();
+                    projectNode.Packages.AddRange(projectAssetsJsonResult.Packages);
+                    projectNode.Dependencies.AddRange(projectAssetsJsonResult.Dependencies);
                 }
 
                 if (projectNode != null && projectNode.Dependencies != null && projectNode.Packages != null)


### PR DESCRIPTION
Load Assets JSON file only if it's path is resolvable and as secondary to the default Asset JSON file in the project root folder.
Resolves IDETECT-4062

Tests were carried out and the results are available.
