### PR TITLE
Add BadParseException handling logic

### DIFF
--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/DependencyResult.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/DependencyResult.cs
@@ -12,5 +12,6 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution
         public string ProjectVersion { get; set; } = null;
         public List<Model.PackageSet> Packages { get; set; } = new List<Model.PackageSet>();
         public List<Model.PackageId> Dependencies { get; set; } = new List<Model.PackageId>();
+        public bool BadParse { get; set; } = false;
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectReferenceResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectReferenceResolver.cs
@@ -101,6 +101,11 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
                     }
                 }
 
+                if (deps.Count > 0 && result.Packages.Count == 0)
+                {
+                    result.BadParse = true;
+                }
+
                 return result;
             }
             catch (InvalidProjectFileException e)

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
@@ -24,7 +24,7 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
         {
             var result = new DependencyResult();
             var tree = new NugetTreeResolver(NugetSearchService);
-
+            
             // .NET core default version
             result.ProjectVersion = "1.0.0";
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
@@ -100,6 +100,11 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
                 {
                     result.Dependencies.Add(package.PackageId);
                 }
+            }
+
+            if (packagesNodes.Count > 0 && result.Packages.Count == 0)
+            {
+                result.BadParse = true;
             }
 
             return result;

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
@@ -191,6 +191,10 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                         Console.WriteLine("Reference resolver succeeded.");
                         projectNode.Packages = projectReferencesResult.Packages;
                         projectNode.Dependencies = projectReferencesResult.Dependencies;
+                        if (projectNode.Dependencies.Count == 0 && projectNode.Packages.Count == 0 && projectReferencesResult.BadParse)
+                        {
+                            throw new Exception("BadParseException: Will try redirecting to Project Inspector");
+                        }
                     }
                     else
                     {
@@ -200,10 +204,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                         projectNode.Version = xmlResult.ProjectVersion;
                         projectNode.Packages = xmlResult.Packages;
                         projectNode.Dependencies = xmlResult.Dependencies;
-                    }
-                    if (projectNode != null && projectNode.Dependencies != null && projectNode.Packages != null)
-                    {
-                        if (projectNode.Dependencies.Count == 0 && projectNode.Packages.Count == 0)
+                        if (projectNode.Dependencies.Count == 0 && projectNode.Packages.Count == 0 && xmlResult.BadParse)
                         {
                             throw new Exception("BadParseException: Will try redirecting to Project Inspector");
                         }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
@@ -201,6 +201,13 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                         projectNode.Packages = xmlResult.Packages;
                         projectNode.Dependencies = xmlResult.Dependencies;
                     }
+                    if (projectNode != null && projectNode.Dependencies != null && projectNode.Packages != null)
+                    {
+                        if (projectNode.Dependencies.Count == 0 && projectNode.Packages.Count == 0)
+                        {
+                            throw new Exception("BadParseException: Will try redirecting to Project Inspector");
+                        }
+                    }
                 }
 
                 var projectAssetsJsonPathFromProperty = GetProjectAssetsJsonPathFromNugetProperty(Options.ProjectDirectory, Options.ProjectName);

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
@@ -191,7 +191,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                         Console.WriteLine("Reference resolver succeeded.");
                         projectNode.Packages = projectReferencesResult.Packages;
                         projectNode.Dependencies = projectReferencesResult.Dependencies;
-                        if (projectNode.Dependencies.Count == 0 && projectNode.Packages.Count == 0 && projectReferencesResult.BadParse)
+                        if (projectReferencesResult.BadParse)
                         {
                             throw new Exception("BadParseException: Will try redirecting to Project Inspector");
                         }
@@ -204,7 +204,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                         projectNode.Version = xmlResult.ProjectVersion;
                         projectNode.Packages = xmlResult.Packages;
                         projectNode.Dependencies = xmlResult.Dependencies;
-                        if (projectNode.Dependencies.Count == 0 && projectNode.Packages.Count == 0 && xmlResult.BadParse)
+                        if (xmlResult.BadParse)
                         {
                             throw new Exception("BadParseException: Will try redirecting to Project Inspector");
                         }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
@@ -139,7 +139,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                             }, NugetService);
 
                             InspectionResult projectResult = projectInspector.Inspect();
-                            if (projectResult != null && projectResult.Containers != null)
+                            if (projectResult != null && projectResult.Status == InspectionResult.ResultStatus.Success && projectResult.Containers != null)
                             {
                                 if (packages.Count > 0)
                                 {
@@ -152,6 +152,10 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                                     }
                                 }
                                 solution.Children.AddRange(projectResult.Containers);
+                            }
+                            else if (projectResult.Status == InspectionResult.ResultStatus.Error)
+                            {
+                                throw new Exception(projectResult.Exception.ToString());
                             }
                         }
                         catch (Exception ex)


### PR DESCRIPTION
This PR will handle the falling back to PI logic for Nuget Inspector when there is a Bad Parse Exception to resolve ticket IDETECT-3515. 

A BadParseException essentially means that whenever the Nuget Native Project Inspector will fall into the last else condition and it will not find any dependencies or packages. This will be handled by throwing an exception and asking Detect to fall back to PI to get LOW accuracy when customer allows for the same.

I have tested few of the cases which are mentioned below and they are working as expected and are falling back to PI when needed:

- Empty sln project file
- Sln file included with a project that contains csproj that hits BadParseException
- Good csproj file that returns components while using xml resolver
- Csproj file hitting BadParseException ( file from ticket )
- Current Nuget Tests that are cascading to PI.
- Empty csproj file with no dependencies.