### PR TITLE
Bump Up Nuget Inspector Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 ext.dotNetExec = project.hasProperty('dotNetExec') ? project.getProperty('dotNetExec') : 'dotnet6'
 
 group 'com.synopsys.integration'
-version = '1.1.0-SNAPSHOT'
+version = '1.2.0-SNAPSHOT'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'distribution'


### PR DESCRIPTION
Change build.gradle to bump up to new Nuget-Inspector version to 1.2.0-SNAPSHOT for new release.