### PR TITLE
Add support for multi-line PackageReference format

### DIFF
--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
@@ -82,11 +82,6 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
                     {
                         XmlAttribute include = attributes["Include"];
                         XmlAttribute version = attributes["Version"];
-                        if (include != null && version != null)
-                        {
-                            var dep = new NugetDependency(include.Value, NuGet.Versioning.VersionRange.Parse(version.Value));
-                            tree.Add(dep);
-                        }
                         String versionStr = null;
                         if (version == null)
                         {

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
@@ -87,6 +87,25 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
                             var dep = new NugetDependency(include.Value, NuGet.Versioning.VersionRange.Parse(version.Value));
                             tree.Add(dep);
                         }
+                        if (version == null)
+                        {
+                            String versionStr = null;
+
+                            foreach (XmlNode node in package.ChildNodes)
+                            {
+                                if (node.Name == "Version")
+                                {
+                                    versionStr = node.InnerXml;
+                                    break;
+                                }
+                            }
+
+                            if (include != null && !String.IsNullOrWhiteSpace(versionStr))
+                            {
+                                var dep = new NugetDependency(include.Value, NuGet.Versioning.VersionRange.Parse(versionStr));
+                                tree.Add(dep);
+                            }
+                        }
                     }
                 }
             }

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
@@ -87,10 +87,9 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
                             var dep = new NugetDependency(include.Value, NuGet.Versioning.VersionRange.Parse(version.Value));
                             tree.Add(dep);
                         }
+                        String versionStr = null;
                         if (version == null)
                         {
-                            String versionStr = null;
-
                             foreach (XmlNode node in package.ChildNodes)
                             {
                                 if (node.Name == "Version")
@@ -99,12 +98,15 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
                                     break;
                                 }
                             }
-
-                            if (include != null && !String.IsNullOrWhiteSpace(versionStr))
-                            {
-                                var dep = new NugetDependency(include.Value, NuGet.Versioning.VersionRange.Parse(versionStr));
-                                tree.Add(dep);
-                            }
+                        }
+                        else
+                        {
+                            versionStr = version.Value;
+                        }
+                        if (include != null && !String.IsNullOrWhiteSpace(versionStr))
+                        {
+                            var dep = new NugetDependency(include.Value, NuGet.Versioning.VersionRange.Parse(versionStr));
+                            tree.Add(dep);
                         }
                     }
                 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryBuildPropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryBuildPropertyLoader.cs
@@ -70,6 +70,23 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                     {
                         packageReferences.Add(new PackageId(name, version));
                     }
+
+                    if (String.IsNullOrWhiteSpace(version))
+                    {
+                        foreach (XmlNode node in packageNode.ChildNodes)
+                        {
+                            if (node.Name == "Version")
+                            {
+                                version = node.InnerXml;
+                                break;
+                            }
+                        }
+                        
+                        if (!String.IsNullOrWhiteSpace(name) && !String.IsNullOrWhiteSpace(version))
+                        {
+                            packageReferences.Add(new PackageId(name, version));
+                        }
+                    }
                 }
             }
             return packageReferences;

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryBuildPropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryBuildPropertyLoader.cs
@@ -65,12 +65,6 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                             version = at.Value;
                         }
                     }
-
-                    if (!String.IsNullOrWhiteSpace(name) && !String.IsNullOrWhiteSpace(version))
-                    {
-                        packageReferences.Add(new PackageId(name, version));
-                    }
-
                     if (String.IsNullOrWhiteSpace(version))
                     {
                         foreach (XmlNode node in packageNode.ChildNodes)
@@ -81,11 +75,10 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                                 break;
                             }
                         }
-                        
-                        if (!String.IsNullOrWhiteSpace(name) && !String.IsNullOrWhiteSpace(version))
-                        {
-                            packageReferences.Add(new PackageId(name, version));
-                        }
+                    }
+                    if (!String.IsNullOrWhiteSpace(name) && !String.IsNullOrWhiteSpace(version))
+                    {
+                        packageReferences.Add(new PackageId(name, version));
                     }
                 }
             }


### PR DESCRIPTION
In the recent push here: https://github.com/blackducksoftware/detect-nuget-inspector/pull/9, the fix was to identify a BadParseException and cascade back to PI when we hit that. But, the cause of this exception was whenever we had PackageReference in the below format:
`<PackageReference Include="System.Formats.Asn1"> 
<Version>6.0.0</Version>
</PackageReference>`
The current code was only parsing over Attributes in the property so, I made changes to support Version tags if there are any. I am keeping the BadParseException check as it is just in case we encounter this in the future.