### PR TITLE
Add Support for Central Package Management in Nuget

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 ext.dotNetExec = project.hasProperty('dotNetExec') ? project.getProperty('dotNetExec') : 'dotnet6'
 
 group 'com.synopsys.integration'
-version = '1.2.0-SIGQA5'
+version = '1.2.0-SIGQA6-SNAPSHOT'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'distribution'

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 ext.dotNetExec = project.hasProperty('dotNetExec') ? project.getProperty('dotNetExec') : 'dotnet6'
 
 group 'com.synopsys.integration'
-version = '1.2.0-SIGQA3-SNAPSHOT'
+version = '1.2.0-SIGQA3'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'distribution'

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 ext.dotNetExec = project.hasProperty('dotNetExec') ? project.getProperty('dotNetExec') : 'dotnet6'
 
 group 'com.synopsys.integration'
-version = '1.2.0-SIGQA4-SNAPSHOT'
+version = '1.2.0-SIGQA4'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'distribution'

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 ext.dotNetExec = project.hasProperty('dotNetExec') ? project.getProperty('dotNetExec') : 'dotnet6'
 
 group 'com.synopsys.integration'
-version = '1.2.0-SIGQA5-SNAPSHOT'
+version = '1.2.0-SIGQA5'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'distribution'

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 ext.dotNetExec = project.hasProperty('dotNetExec') ? project.getProperty('dotNetExec') : 'dotnet6'
 
 group 'com.synopsys.integration'
-version = '1.2.0-SIGQA3'
+version = '1.2.0-SIGQA4-SNAPSHOT'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'distribution'

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 ext.dotNetExec = project.hasProperty('dotNetExec') ? project.getProperty('dotNetExec') : 'dotnet6'
 
 group 'com.synopsys.integration'
-version = '1.2.0-SIGQA4'
+version = '1.2.0-SIGQA5-SNAPSHOT'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'distribution'

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/Files/CPM_Disabled_Directory.Packages.props
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/Files/CPM_Disabled_Directory.Packages.props
@@ -1,0 +1,11 @@
+<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include="IsExternalInit" Version="1.0.3" />
+        <PackageVersion Include="MessagePack" Version="2.2.85" />
+        <PackageVersion Include="MessagePackAnalyzer" Version="2.5.108" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" />
+    </ItemGroup>
+</Project>

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/Files/GlobalPackageReference_Directory.Packages.props
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/Files/GlobalPackageReference_Directory.Packages.props
@@ -1,0 +1,37 @@
+<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include="IsExternalInit" Version="1.0.3" />
+        <PackageVersion Include="Microsoft.CodeAnalysis" Version="$(CodeAnalysisVersion)" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisVersion)" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="$(CodefixTestingVersion)" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit" Version="$(CodefixTestingVersion)" />
+        <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.6.17" />
+        <PackageVersion Include="Microsoft.VisualStudio.RpcContracts" Version="17.6.13" />
+        <PackageVersion Include="Microsoft.VisualStudio.Utilities" Version="17.6.36011" />
+        <PackageVersion Include="Microsoft.VisualStudio.Utilities.Testing" Version="17.5.33627.172" />
+        <PackageVersion Include="Microsoft.VisualStudio.Sdk.TestFramework.Xunit" Version="17.6.16" />
+        <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.6.11" />
+        <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+        <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
+        <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="$(VSThreadingVersion)" />
+        <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(VSThreadingVersion)" />
+        <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.2.188-beta" />
+        <PackageVersion Include="Nerdbank.Streams" Version="2.10.69" />
+    </ItemGroup>
+    <ItemGroup>
+        <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.495" />
+        <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
+        <GlobalPackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" />
+        <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" />
+        <GlobalPackageReference Include="Nullable" Version="1.3.1" Condition="'$(DoNotReferenceNullable)'!='true'" />
+        <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507" />
+    </ItemGroup>
+    <ItemGroup>
+        <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    </ItemGroup>
+</Project>

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/Files/Standard_Directory.Packages.props
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/Files/Standard_Directory.Packages.props
@@ -1,0 +1,27 @@
+<Project ToolsVersion="15.0">
+    <PropertyGroup>
+        <CentralPackageVersionOverrideEnabled>true</CentralPackageVersionOverrideEnabled>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+        <PackageVersion Include="Microsoft.Windows.Compatibility" Version="7.0.5" />
+        <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
+        <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.4.231008000" />
+        <PackageVersion Include="SkiaSharp.Skottie" Version="2.88.6" />
+        <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.6" />
+        <PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
+        <PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.7.0" />
+        <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.7.0" />
+        <PackageVersion Include="Uno.Resizetizer" Version="1.2.0" />
+        <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.0.19" />
+        <PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
+        <PackageVersion Include="Uno.Wasm.Bootstrap" Version="7.0.24" />
+        <PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.24" />
+        <PackageVersion Include="Uno.Wasm.Bootstrap.Server" Version="7.0.24" />
+        <PackageVersion Include="Uno.WinUI" Version="5.0.19" />
+        <PackageVersion Include="Uno.WinUI.DevServer" Version="5.0.19" />
+        <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="5.0.19" />
+        <PackageVersion Include="Uno.WinUI.WebAssembly" Version="5.0.19" />
+        <PackageVersion Include="Xamarin.Google.Android.Material" Version="1.10.0.1" />
+    </ItemGroup>
+</Project>

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/Files/Standard_Directory.Packages.props
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/Files/Standard_Directory.Packages.props
@@ -1,6 +1,8 @@
 <Project ToolsVersion="15.0">
     <PropertyGroup>
         <CentralPackageVersionOverrideEnabled>true</CentralPackageVersionOverrideEnabled>
+        <CodeAnalysisVersion>4.6.0</CodeAnalysisVersion>
+        <CodefixTestingVersion>1.1.2-beta1.23357.1</CodefixTestingVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
@@ -13,6 +15,8 @@
         <PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.7.0" />
         <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.7.0" />
         <PackageVersion Include="Uno.Resizetizer" Version="1.2.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="$(CodefixTestingVersion)" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisVersion)" />
         <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.0.19" />
         <PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
         <PackageVersion Include="Uno.Wasm.Bootstrap" Version="7.0.24" />

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/Files/VersionOverride_Disabled_Directory.Packages.props
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/Files/VersionOverride_Disabled_Directory.Packages.props
@@ -1,0 +1,11 @@
+<Project>
+    <PropertyGroup>
+        <CentralPackageVersionOverrideEnabled>false</CentralPackageVersionOverrideEnabled>
+    </PropertyGroup>
+    <ItemGroup>
+        <ItemGroup>
+            <PackageVersion Include="PackageA" Version="1.0.0" />
+            <PackageVersion Include="PackageB" Version="2.0.0" />
+        </ItemGroup>
+    </ItemGroup>
+</Project>

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/Inspection/Util/SolutionDirectoryPackagesPropertyLoaderTests.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/Inspection/Util/SolutionDirectoryPackagesPropertyLoaderTests.cs
@@ -27,10 +27,11 @@ namespace detect_nuget_inspector_tests.Inspection.Util
             bool versionOverrideEnabled = solutionDirectoryPackagesPropertyLoader.GetVersionOverrideEnabled();
 
             Assert.IsNotNull(packageVersions);
-            Assert.AreEqual(20, packageVersions.Count);
+            Assert.AreEqual(22, packageVersions.Count);
             Assert.AreEqual(true,versionOverrideEnabled);
             Assert.AreEqual("2.88.6",packageVersions.First(pkg => pkg.Name.Equals("SkiaSharp.Views.Uno.WinUI")).Version);
-            Assert.AreEqual("5.0.19",packageVersions.First(pkg => pkg.Name.Equals("Uno.WinUI.WebAssembly")).Version);
+            Assert.AreEqual("4.6.0",packageVersions.First(pkg => pkg.Name.Equals("Microsoft.CodeAnalysis.CSharp")).Version);
+            Assert.AreEqual("1.1.2-beta1.23357.1",packageVersions.First(pkg => pkg.Name.Equals("Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit")).Version);
         }
 
         [TestMethod]

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/Inspection/Util/SolutionDirectoryPackagesPropertyLoaderTests.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/Inspection/Util/SolutionDirectoryPackagesPropertyLoaderTests.cs
@@ -1,0 +1,85 @@
+using System.Security.Policy;
+using Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors;
+using Synopsys.Detect.Nuget.Inspector.Model;
+
+namespace detect_nuget_inspector_tests.Inspection.Util
+{
+    [TestClass]
+    public class SolutionDirectoryPackagesPropertyLoaderTests
+    {
+        private string GetFilePath(string fileName)
+        {
+            string projectDirectory = Directory.GetParent(Environment.CurrentDirectory).Parent.Parent.FullName;
+            string filePath = Path.Combine(projectDirectory, "Files", fileName);
+
+            return filePath;
+        }
+        
+        [TestMethod]
+        public void ParseStandardDirectoryPackagesPropsFile()
+        {
+            string propertyPath = GetFilePath("Standard_Directory.Packages.props"); 
+            
+            var solutionDirectoryPackagesPropertyLoader =
+                new SolutionDirectoryPackagesPropertyLoader(GetFilePath(propertyPath));
+
+            HashSet<PackageId> packageVersions = solutionDirectoryPackagesPropertyLoader.Process();
+            bool versionOverrideEnabled = solutionDirectoryPackagesPropertyLoader.GetVersionOverrideEnabled();
+
+            Assert.IsNotNull(packageVersions);
+            Assert.AreEqual(20, packageVersions.Count);
+            Assert.AreEqual(true,versionOverrideEnabled);
+            Assert.AreEqual("2.88.6",packageVersions.First(pkg => pkg.Name.Equals("SkiaSharp.Views.Uno.WinUI")).Version);
+            Assert.AreEqual("5.0.19",packageVersions.First(pkg => pkg.Name.Equals("Uno.WinUI.WebAssembly")).Version);
+        }
+
+        [TestMethod]
+        public void ParseDirectoryPackagesPropsFileWithCpmDisabled()
+        {
+            string propertyPath = GetFilePath("CPM_Disabled_Directory.Packages.props");
+            
+            var solutionDirectoryPackagesPropertyLoader =
+                new SolutionDirectoryPackagesPropertyLoader(GetFilePath(propertyPath));
+            
+            StringWriter stringWriter = new StringWriter();
+            Console.SetOut(stringWriter);
+            
+            HashSet<PackageId> packageVersions = solutionDirectoryPackagesPropertyLoader.Process();
+            
+            Assert.AreEqual(0, packageVersions.Count);
+            Assert.AreEqual( "The user has disabled Central Package Management. Will skip parsing over this file\n",stringWriter.ToString());
+        }
+
+        [TestMethod]
+        public void ParseDirectoryPackagesPropsFileWithVersionOverrideDisabled()
+        {
+            string propertyPath = GetFilePath("VersionOverride_Disabled_Directory.Packages.props");
+            
+            var solutionDirectoryPackagesPropertyLoader =
+                new SolutionDirectoryPackagesPropertyLoader(GetFilePath(propertyPath));
+            
+            bool versionOverrideEnabled = solutionDirectoryPackagesPropertyLoader.GetVersionOverrideEnabled();
+            
+            Assert.AreEqual(false, versionOverrideEnabled);
+        }
+        
+        [TestMethod]
+        public void ParseDirectoryPackagesPropsFileWithGlobalPackageReferences()
+        {
+            string propertyPath = GetFilePath("GlobalPackageReference_Directory.Packages.props");
+            
+            var solutionDirectoryPackagesPropertyLoader =
+                new SolutionDirectoryPackagesPropertyLoader(GetFilePath(propertyPath));
+
+            HashSet<PackageId> packageVersions = solutionDirectoryPackagesPropertyLoader.Process();
+
+            HashSet<PackageId> globalPackageReferences =
+                solutionDirectoryPackagesPropertyLoader.GetGlobalPackageReferences();
+            
+            Assert.AreEqual(19,packageVersions.Count);
+            Assert.AreEqual(7,globalPackageReferences.Count);
+            Assert.AreEqual("1.2.0.507",globalPackageReferences.First(pkg => pkg.Name.Equals("StyleCop.Analyzers.Unstable")).Version);
+            Assert.AreEqual("1.1.1",globalPackageReferences.First(pkg => pkg.Name.Equals("Microsoft.SourceLink.GitHub")).Version);
+        }
+    }
+}

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/DependencyResult.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/DependencyResult.cs
@@ -12,6 +12,5 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution
         public string ProjectVersion { get; set; } = null;
         public List<Model.PackageSet> Packages { get; set; } = new List<Model.PackageSet>();
         public List<Model.PackageId> Dependencies { get; set; } = new List<Model.PackageId>();
-        public bool BadParse { get; set; } = false;
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectReferenceResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectReferenceResolver.cs
@@ -122,7 +122,7 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
                 {
                     Success = true,
                     Packages = tree.GetPackageList(),
-                    Dependencies = new List<PackageId>(),
+                    Dependencies = new List<PackageId>()
                 };
 
                 foreach (var package in result.Packages)

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectReferenceResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectReferenceResolver.cs
@@ -43,7 +43,7 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
                 List<NugetDependency> deps = new List<NugetDependency>();
                 foreach (ProjectItem reference in proj.GetItemsIgnoringCondition("PackageReference"))
                 {
-                    bool containsPkg = Packages.Any(pkg => pkg.Name.Equals(reference.EvaluatedInclude));
+                    bool containsPkg = Packages != null && Packages.Any(pkg => pkg.Name.Equals(reference.EvaluatedInclude));
                     var versionMetaData = reference.Metadata.Where(meta => meta.Name == "Version").FirstOrDefault();
                     var versionOverrideMetaData = reference.Metadata.Where(meta => meta.Name == "VersionOverride").FirstOrDefault();
                     if (containsPkg && versionOverrideMetaData != null && CheckVersionOverride)
@@ -122,7 +122,7 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
                 {
                     Success = true,
                     Packages = tree.GetPackageList(),
-                    Dependencies = new List<PackageId>()
+                    Dependencies = new List<PackageId>(),
                 };
 
                 foreach (var package in result.Packages)

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
@@ -123,7 +123,7 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
 
                         if (include != null)
                         {
-                            bool containsPkg = Packages.Any(pkg => pkg.Name.Equals(include.Value));
+                            bool containsPkg = Packages != null && Packages.Any(pkg => pkg.Name.Equals(include.Value));
                             if (!String.IsNullOrWhiteSpace(versionOverrideStr))
                             {
                                 if (containsPkg && CheckVersionOverride)

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
@@ -142,11 +142,7 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
                             }
                             else
                             {
-                                if (!containsPkg)
-                                {
-                                    result.BadParse = true;
-                                }
-                                else
+                                if(containsPkg)
                                 {
                                     PackageId pkg = Packages.First(pkg => pkg.Name.Equals(include.Value));
                                     

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
@@ -21,7 +21,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
     {
         public ProjectInspectionOptions Options;
         public NugetSearchService NugetService;
-        private HashSet<PackageId> Packages;
+        private HashSet<PackageId> CentrallyManagedPackages;
         private bool CheckVersionOverride;
 
         public ProjectInspector(ProjectInspectionOptions options, NugetSearchService nugetService)
@@ -79,61 +79,9 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
             }
         }
         
-        public ProjectInspector(ProjectInspectionOptions options, NugetSearchService nugetService, HashSet<PackageId> packages, bool checkVersionOverride)
+        public ProjectInspector(ProjectInspectionOptions options, NugetSearchService nugetService, HashSet<PackageId> packages, bool checkVersionOverride): this(options, nugetService)
         {
-            Options = options;
-            NugetService = nugetService;
-            if (Options == null)
-            {
-                throw new Exception("Must provide a valid options object.");
-            }
-
-            if (String.IsNullOrWhiteSpace(Options.ProjectDirectory))
-            {
-                Options.ProjectDirectory = Directory.GetParent(Options.TargetPath).FullName;
-            }
-
-            if (String.IsNullOrWhiteSpace(Options.PackagesConfigPath))
-            {
-                Options.PackagesConfigPath = CreateProjectPackageConfigPath(Options.ProjectDirectory);
-            }
-
-            if (String.IsNullOrWhiteSpace(Options.ProjectJsonPath))
-            {
-                Options.ProjectJsonPath = CreateProjectJsonPath(Options.ProjectDirectory);
-            }
-
-            if (String.IsNullOrWhiteSpace(Options.ProjectJsonLockPath))
-            {
-                Options.ProjectJsonLockPath = CreateProjectJsonLockPath(Options.ProjectDirectory);
-            }
-
-            if (String.IsNullOrWhiteSpace(Options.ProjectName))
-            {
-                Options.ProjectName = Path.GetFileNameWithoutExtension(Options.TargetPath);
-            }
-
-            if (String.IsNullOrWhiteSpace(Options.ProjectAssetsJsonPath))
-            {
-                Options.ProjectAssetsJsonPath = CreateProjectAssetsJsonPath(Options.ProjectDirectory);
-            }
-
-            if (String.IsNullOrWhiteSpace(Options.ProjectUniqueId))
-            {
-                Options.ProjectUniqueId = Path.GetFileNameWithoutExtension(Options.TargetPath);
-            }
-
-            if (String.IsNullOrWhiteSpace(Options.VersionName))
-            {
-                Options.VersionName = InspectorUtil.GetProjectAssemblyVersion(Options.ProjectDirectory);
-            }
-
-            if (String.IsNullOrWhiteSpace(Options.DirectoryPackagesPropsPath))
-            {
-                Options.DirectoryPackagesPropsPath = CreateDirectoryPackagesPropsPath(Options.ProjectDirectory);
-            }
-
-            Packages = packages;
+            CentrallyManagedPackages = packages;
             CheckVersionOverride = checkVersionOverride;
         }
 
@@ -260,9 +208,9 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                 {
                     Console.WriteLine("Attempting reference resolver: " + Options.TargetPath);
                     ProjectReferenceResolver referenceResolver;
-                    if (Packages != null && Packages.Count > 0)
+                    if (CentrallyManagedPackages != null && CentrallyManagedPackages.Count > 0)
                     {
-                        referenceResolver = new ProjectReferenceResolver(Options.TargetPath, NugetService, Packages, CheckVersionOverride);
+                        referenceResolver = new ProjectReferenceResolver(Options.TargetPath, NugetService, CentrallyManagedPackages, CheckVersionOverride);
                     }
                     else
                     {
@@ -279,9 +227,9 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                     {
                         Console.WriteLine("Using backup XML resolver.");
                         ProjectXmlResolver xmlResolver;
-                        if (Packages != null && Packages.Count > 0)
+                        if (CentrallyManagedPackages != null && CentrallyManagedPackages.Count > 0)
                         {
-                            xmlResolver = new ProjectXmlResolver(Options.TargetPath, NugetService, Packages, CheckVersionOverride);
+                            xmlResolver = new ProjectXmlResolver(Options.TargetPath, NugetService, CentrallyManagedPackages, CheckVersionOverride);
                         }
                         else
                         {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
@@ -220,7 +220,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                 {
                     Console.WriteLine("Using Central Package Management: " + Options.DirectoryPackagesPropsPath);
                     var packagesPropertyLoader =
-                        new SolutionDirectoryPackagesPropertyLoader(Options.DirectoryPackagesPropsPath, NugetService);
+                        new SolutionDirectoryPackagesPropertyLoader(Options.DirectoryPackagesPropsPath);
                     projectNode.PackagePropertyPackages = packagesPropertyLoader.Process();
                     projectNode.Dependencies = packagesPropertyLoader.GetGlobalPackageReferences().ToList();
                 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
@@ -291,10 +291,6 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                         projectNode.Version = xmlResult.ProjectVersion;
                         projectNode.Packages = xmlResult.Packages;
                         projectNode.Dependencies = xmlResult.Dependencies;
-                        if (xmlResult.BadParse)
-                        {
-                            throw new Exception("BadParseException: Will try redirecting to Project Inspector");
-                        }
                     }
                 }
 

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspectorOptions.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspectorOptions.cs
@@ -29,5 +29,6 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
         public string ProjectJsonPath { get; set; }
         public string ProjectJsonLockPath { get; set; }
         public string ProjectAssetsJsonPath { get; set; }
+        public string DirectoryPackagesPropsPath { get; set; }
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
@@ -130,9 +130,9 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                                 while (fileNotFound)
                                 {
                                     parentPath =
-                                        parentPath.Substring(0, parentPath.LastIndexOf("/"));
+                                        parentPath.Substring(0, OperatingSystem.IsWindows() ? parentPath.LastIndexOf("\\") : parentPath.LastIndexOf("/"));
                                     string checkFile = Path.Combine(parentPath, projectRelativePath);
-                                    if (parentPath.Equals("/"))
+                                    if (parentPath.Equals("/") || parentPath.Equals("\\"))
                                     {
                                         Console.WriteLine("The Path provided in the sln file is wrong, will skip parsing over this file");
                                         break;

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
@@ -84,6 +84,16 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                     packages = propertyLoader.Process();
                 }
 
+                string solutionDirectoryPackagesPropertyPath = CreateSolutionDirectoryPackagesPropertyPath(parentDirectory);
+                bool solutionDirectoryPackagesPropertyExists = !String.IsNullOrWhiteSpace(solutionDirectoryPackagesPropertyPath) && File.Exists(solutionDirectoryPackagesPropertyPath);
+
+                if (solutionDirectoryPackagesPropertyExists)
+                {
+                    Console.WriteLine("Using solution directory packages property file: " + solutionDirectoryPackagesPropertyPath);
+                    var packagePropertyLoader = new SolutionDirectoryPackagesPropertyLoader(solutionDirectoryPackagesPropertyPath, NugetService);
+                    packages = packagePropertyLoader.Process();
+                }
+                
                 List<ProjectFile> projectFiles = FindProjectFilesFromSolutionFile(Options.TargetPath, ExcludedProjectTypeGUIDs);
                 Console.WriteLine("Parsed Solution File");
                 if (projectFiles.Count > 0)
@@ -235,6 +245,11 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
         private string CreateSolutionDirectoryBuildPropertyPath(string solutionDirectory)
         {
             return PathUtil.Combine(solutionDirectory, "Directory.Build.props");
+        }
+        
+        private string CreateSolutionDirectoryPackagesPropertyPath(string solutionDirectory)
+        {
+            return PathUtil.Combine(solutionDirectory, "Directory.Packages.props");
         }
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
@@ -269,7 +269,10 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                     if (!projectText.Equals("\t\tDirectory.Packages.props = Directory.Packages.props"))
                     {
                         ProjectFile file = ProjectFile.Parse(projectText);
-                        projects.Add(file);
+                        if (file != null)
+                        { 
+                            projects.Add(file);
+                        }
                     }
                 }
                 foreach (string projectText in projectLines)

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
@@ -132,7 +132,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                                     parentPath =
                                         parentPath.Substring(0, OperatingSystem.IsWindows() ? parentPath.LastIndexOf("\\") : parentPath.LastIndexOf("/"));
                                     string checkFile = Path.Combine(parentPath, projectRelativePath);
-                                    if (parentPath.Equals("/") || parentPath.Equals("\\"))
+                                    if (parentPath.Equals(Path.GetPathRoot(solutionDirectory)))
                                     {
                                         Console.WriteLine("The Path provided in the sln file is wrong, will skip parsing over this file");
                                         break;

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
@@ -81,7 +81,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                 if (solutionDirectoryPackagesPropertyExists)
                 {
                     Console.WriteLine("Using solution directory packages property file: " + solutionDirectoryPackagesPropertyPath);
-                    var packagePropertyLoader = new SolutionDirectoryPackagesPropertyLoader(solutionDirectoryPackagesPropertyPath, NugetService);
+                    var packagePropertyLoader = new SolutionDirectoryPackagesPropertyLoader(solutionDirectoryPackagesPropertyPath);
                     packagesProperty = packagePropertyLoader.Process();
                     globalPackageReferences = packagePropertyLoader.GetGlobalPackageReferences();
                     checkVersionOverride = packagePropertyLoader.GetVersionOverrideEnabled();

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Model/Container.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Model/Container.cs
@@ -16,5 +16,6 @@ namespace Synopsys.Detect.Nuget.Inspector.Model
         public List<PackageSet> Packages { get; set; } = new List<PackageSet>();
         public List<PackageId> Dependencies { get; set; } = new List<PackageId>();
         public List<Container> Children { get; set; } = new List<Container>();
+        public HashSet<PackageId> PackagePropertyPackages { get; set; } = new HashSet<PackageId>();
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/ProjectFile.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/ProjectFile.cs
@@ -28,7 +28,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
             {
                 file.TypeGUID = MiddleOfString(leftSide, "Project(\"".Length, "\")".Length);
             }
-            else
+            else if(rightSide.Contains("Directory.Packages.props"))
             {
                 rightSide = rightSide.Split("..\\")[1];
                 file.Path = rightSide.Replace("\\", "/");

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/ProjectFile.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/ProjectFile.cs
@@ -28,6 +28,12 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
             {
                 file.TypeGUID = MiddleOfString(leftSide, "Project(\"".Length, "\")".Length);
             }
+            else
+            {
+                rightSide = rightSide.Split("..\\")[1];
+                file.Path = rightSide.Replace("\\", "/");
+                return file;
+            }
             var opts = rightSide.Split(',').Select(s => s.Trim()).ToList();
             if (opts.Count() >= 1) file.Name = MiddleOfString(opts[0], 1, 1); //strip quotes
             if (opts.Count() >= 2) file.Path = MiddleOfString(opts[1], 1, 1); //strip quotes

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/ProjectFile.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/ProjectFile.cs
@@ -31,7 +31,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
             else if(rightSide.Contains("Directory.Packages.props"))
             {
                 rightSide = rightSide.Split("..\\")[1];
-                file.Path = rightSide.Replace("\\", "/");
+                file.Path = OperatingSystem.IsWindows() ? rightSide : rightSide.Replace("\\", "/");
                 return file;
             }
             var opts = rightSide.Split(',').Select(s => s.Trim()).ToList();

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryBuildPropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryBuildPropertyLoader.cs
@@ -54,6 +54,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                     XmlAttributeCollection attributes = packageNode.Attributes;
                     string name = null;
                     string version = null;
+                    string versionOverride = null;
                     foreach (XmlAttribute at in attributes)
                     {
                         if (at.LocalName.Contains("Include"))
@@ -64,25 +65,63 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                         {
                             version = at.Value;
                         }
+                        else if (at.LocalName.Contains("VersionOverride"))
+                        {
+                            versionOverride = at.Value;
+                        }
                     }
-                    if (String.IsNullOrWhiteSpace(version))
+                    if (String.IsNullOrWhiteSpace(version) && String.IsNullOrWhiteSpace(versionOverride))
                     {
                         foreach (XmlNode node in packageNode.ChildNodes)
                         {
                             if (node.Name == "Version")
                             {
                                 version = node.InnerXml;
+                            }
+                            else if(node.Name == "VersionOverride")
+                            {
+                                versionOverride = node.InnerXml;
                                 break;
                             }
                         }
                     }
-                    if (!String.IsNullOrWhiteSpace(name) && !String.IsNullOrWhiteSpace(version))
+
+                    string versionStr = !String.IsNullOrWhiteSpace(versionOverride) ? versionOverride : version;
+                    if (!String.IsNullOrWhiteSpace(name) && !String.IsNullOrWhiteSpace(versionStr))
                     {
-                        packageReferences.Add(new PackageId(name, version));
+                        packageReferences.Add(new PackageId(name, versionStr));
                     }
                 }
             }
             return packageReferences;
+        }
+        
+        public bool GetCentralTransitivePinning()
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+            XmlDocument doc = new XmlDocument();
+            doc.Load(PropertyPath);
+            
+            XmlNodeList centralTransitivePinning = doc.GetElementsByTagName("CentralPackageTransitivePinningEnabled");
+
+            bool checkTransitivePinning = !(centralTransitivePinning != null && centralTransitivePinning.Count > 0 && centralTransitivePinning.Item(0).InnerXml == "false");
+
+            return checkTransitivePinning;
+        }
+        
+        public bool GetVersionOverrideEnabled()
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+            XmlDocument doc = new XmlDocument();
+            doc.Load(PropertyPath);
+            
+            XmlNodeList centralVersionOverride = doc.GetElementsByTagName("CentralPackageVersionOverrideEnabled");
+
+            bool checkVersionOverride = centralVersionOverride != null && centralVersionOverride.Count > 0 && centralVersionOverride.Item(0).InnerXml == "true";
+
+            return checkVersionOverride;
         }
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryPackagesPropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryPackagesPropertyLoader.cs
@@ -97,7 +97,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                         }
                     }
 
-                    if (packageVersion.Contains("$("))
+                    if (packageVersion != null && packageVersion.Contains("$("))
                     {
                         string propertyName = packageVersion.Substring(packageVersion.IndexOf("(") + 1, packageVersion.IndexOf(")") - 2);
                         if (propertyGroups.ContainsKey(propertyName))

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryPackagesPropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryPackagesPropertyLoader.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget;
+using Synopsys.Detect.Nuget.Inspector.Model;
+
+namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors;
+
+public class SolutionDirectoryPackagesPropertyLoader : PackageReferenceLoader
+{
+
+    private String PropertyPath;
+    private NugetSearchService NugetSearchService;
+
+    public SolutionDirectoryPackagesPropertyLoader(String propertyPath, NugetSearchService nugetSearchService)
+    {
+        PropertyPath = propertyPath;
+        NugetSearchService = nugetSearchService;
+    }
+
+    public HashSet<PackageId> Process()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+        XmlDocument doc = new XmlDocument();
+        doc.Load(PropertyPath);
+
+        XmlNodeList manageCentralPackageVersion = doc.GetElementsByTagName("ManagePackageVersionsCentrally");
+        
+        HashSet<PackageId> packageReferences = new HashSet<PackageId>();
+        
+        if (CheckCentralPackageManagementEnabled(manageCentralPackageVersion))
+        {
+            XmlNodeList packageVersionNodes = doc.GetElementsByTagName("PackageVersion");
+
+            if (packageVersionNodes != null && packageVersionNodes.Count > 0)
+            {
+                GetPackageVersions(packageVersionNodes, packageReferences);
+            }
+
+            XmlNodeList globalPackageReferenceNodes = doc.GetElementsByTagName("GlobalPackageReference");
+
+            if (globalPackageReferenceNodes != null && globalPackageReferenceNodes.Count > 0)
+            {
+                GetPackageVersions(globalPackageReferenceNodes,packageReferences);
+            } 
+        }
+        else
+        {
+            Console.WriteLine("The user has disabled Central Package Management. Will skip parsing over this file ");
+        }
+
+        return packageReferences;
+    }
+
+    private bool CheckCentralPackageManagementEnabled(XmlNodeList manageCentralPackageVersion)
+    {
+        return manageCentralPackageVersion != null && manageCentralPackageVersion.Count > 0 &&
+               manageCentralPackageVersion.Item(0).InnerXml == "true";
+    }
+
+    private void GetPackageVersions(XmlNodeList packageVersionNodes, HashSet<PackageId> packageReferences)
+    {
+        foreach (XmlNode packageVersionNode in packageVersionNodes)
+        {
+            if (packageVersionNode.NodeType != XmlNodeType.Comment)
+            {
+                XmlAttributeCollection attributes = packageVersionNode.Attributes;
+                String packageName = null;
+                String packageVersion = null;
+
+                foreach (XmlAttribute attribute in attributes)
+                {
+                    if (attribute.LocalName.Contains("Include"))
+                    {
+                        packageName = attribute.Value;
+                    }
+
+                    if (attribute.LocalName.Contains("Version"))
+                    {
+                        packageVersion = attribute.Value;
+                    }
+
+                    if (!String.IsNullOrWhiteSpace(packageName) && !String.IsNullOrWhiteSpace(packageVersion))
+                    {
+                        packageReferences.Add(new PackageId(packageName, packageVersion));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryPackagesPropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryPackagesPropertyLoader.cs
@@ -181,13 +181,16 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
         {
             Dictionary<string, string> groups = new Dictionary<string, string>();
 
-            if (propertyGroups != null && propertyGroups.Count > 0 && propertyGroups.Item(0).HasChildNodes)
+            if (propertyGroups != null && propertyGroups.Count > 0)
             {
-                foreach (XmlNode node in propertyGroups.Item(0).ChildNodes)
+                foreach (XmlNode propertyGroup in propertyGroups)
                 {
-                    if (!groups.ContainsKey(node.Name))
+                    foreach (XmlNode node in propertyGroup.ChildNodes)
                     {
-                        groups.Add(node.Name, node.InnerXml);
+                        if (!groups.ContainsKey(node.Name))
+                        {
+                            groups.Add(node.Name, node.InnerXml);
+                        }
                     }
                 }
             }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryPackagesPropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryPackagesPropertyLoader.cs
@@ -12,12 +12,10 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
     {
 
         private String PropertyPath;
-        private NugetSearchService NugetSearchService;
 
-        public SolutionDirectoryPackagesPropertyLoader(String propertyPath, NugetSearchService nugetSearchService)
+        public SolutionDirectoryPackagesPropertyLoader(String propertyPath)
         {
             PropertyPath = propertyPath;
-            NugetSearchService = nugetSearchService;
         }
 
         public HashSet<PackageId> Process()
@@ -51,8 +49,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
             }
             else
             {
-                Console.WriteLine(
-                    "The user has disabled Central Package Management. Will skip parsing over this file ");
+                Console.WriteLine("The user has disabled Central Package Management. Will skip parsing over this file");
             }
 
             return packageReferences;


### PR DESCRIPTION
This PR adds support for CPM mentioned in ticket IDETECT-3433 (https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management). New features which are added as part of this work are:

- Parse over Directory.Packages.props file if found inside the root project folder. 
- Support VersionOverride tags if CPM is enabled.
- Parse through all Directory.Packages.props file found inside the project to extend support for sub solution and projects.
- Raise warning if Import of props file is done from a non-root folder.

Battery Tests can be added as part of Detect repo which will be dockerized and part of current integration test suite. Will look at it in case we can add such tests.

Unit Tests which can be added as part of Nuget Inspector are:

- Standard Directory.Packages.props file
- Packages.props with CPM disabled
- Packages.props with Version override Enabled/Disabled
- Packages.props project using Global Package Reference