### PR TITLE
Add Gradle Task for running unit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,21 @@ project.tasks.create(name: 'buildSolutions') {
     description 'Build executable for all defined operating systems'
 }
 
+project.tasks.create(name: 'testUnit', type: Exec){
+    group 'dotnet test'
+    description 'Run all Unit Tests defined inside detect-nuget-inspector-tests and generate test result'
+
+    def buildCommand = [dotNetExec, 'test', 'detect-nuget-inspector/detect-nuget-inspector.sln','--logger:junit']
+    doFirst {
+        logger.lifecycle("Running Unit Tests")
+    }
+    doLast {
+        logger.lifecycle("Output of unit tests located at ${buildDir}/detect-nuget-inspector/detect-nuget-inspector-tests/TestResults/TestResults.xml")
+    }
+
+    commandLine buildCommand
+}
+
 /*
 The lines below will, for each configured solution
     * Create the build task

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/detect-nuget-inspector-tests.csproj
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/detect-nuget-inspector-tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="JunitXml.TestLogger" Version="3.0.110" />
   </ItemGroup>
 
   <ItemGroup>

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/detect-nuget-inspector-tests.csproj
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/detect-nuget-inspector-tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
-    <PackageReference Include="JunitXml.TestLogger" Version="3.0.110" />
+    <PackageReference Include="JunitXml.TestLogger" Version="3.0.134" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR is created to make sure we are running unit tests as part of our regular builds in jenkins. There are 19 unit tests in total which are present in Nuget Inspector project and we can take leverage of those tests being ran on daily basis. An example build ran with this change in the jenkins server can be found here.
 https://build-bd.internal.synopsys.com/job/integration-builds-v2/job/generated-builds/job/solutions/job/detect-nuget-inspector/job/dev/652/