### PR TITLE
Add support for CPM in Build.props file

### DIFF
--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectReferenceResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectReferenceResolver.cs
@@ -24,9 +24,9 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
             NugetSearchService = nugetSearchService;
         }
         
-        public ProjectReferenceResolver(string projectPath, NugetSearchService nugetSearchService, HashSet<PackageId> packages, bool checkVersionOverride): this(projectPath, nugetSearchService)
+        public ProjectReferenceResolver(string projectPath, NugetSearchService nugetSearchService, HashSet<PackageId> centrallyManagedPackages, bool checkVersionOverride): this(projectPath, nugetSearchService)
         {
-            CentrallyManagedPackages = packages;
+            CentrallyManagedPackages = centrallyManagedPackages;
             CheckVersionOverride = checkVersionOverride;
         }
         

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
@@ -22,9 +22,9 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
             NugetSearchService = nugetSearchService;
         }
         
-        public ProjectXmlResolver(string projectPath, NugetSearchService nugetSearchService, HashSet<PackageId> packages, bool checkVersionOverride): this(projectPath, nugetSearchService)
+        public ProjectXmlResolver(string projectPath, NugetSearchService nugetSearchService, HashSet<PackageId> centrallyManagedPackages, bool checkVersionOverride): this(projectPath, nugetSearchService)
         {
-            CentrallyManagedPackages = packages;
+            CentrallyManagedPackages = centrallyManagedPackages;
             CheckVersionOverride = checkVersionOverride;
         }
 

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
@@ -104,7 +104,7 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
                                 
                                 if (!String.IsNullOrWhiteSpace(versionOverrideStr) && CheckVersionOverride)
                                 { 
-                                    addNugetDependency(tree, include.Value, versionStr);
+                                    addNugetDependency(tree, include.Value, versionOverrideStr);
                                 }
                                 else if (!String.IsNullOrWhiteSpace(versionOverrideStr) && !CheckVersionOverride)
                                 {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
@@ -168,7 +168,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                 {
                     Console.WriteLine("Using Central Package Management: " + Options.DirectoryPackagesPropsPath);
                     var packagesPropertyLoader =
-                        new SolutionDirectoryPackagesPropertyLoader(Options.DirectoryPackagesPropsPath);
+                        new SolutionDirectoryPackagesPropertyLoader(Options.DirectoryPackagesPropsPath, CentrallyManagedPackages);
                     projectNode.PackagePropertyPackages = packagesPropertyLoader.Process();
                     projectNode.Dependencies = packagesPropertyLoader.GetGlobalPackageReferences().ToList();
                 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
@@ -94,7 +94,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                 if (solutionDirectoryBuildPropertyExists)
                 {
                     Console.WriteLine("Using solution directory build property file: " + solutionDirectoryBuildPropertyPath);
-                    var propertyLoader = new SolutionDirectoryBuildPropertyLoader(solutionDirectoryBuildPropertyPath, NugetService, checkVersionOverride);
+                    var propertyLoader = new SolutionDirectoryBuildPropertyLoader(solutionDirectoryBuildPropertyPath, NugetService,packagesProperty, checkVersionOverride);
                     buildPropertyPackages = propertyLoader.Process();
                     checkVersionOverride = propertyLoader.GetVersionOverrideEnabled();
                 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryBuildPropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryBuildPropertyLoader.cs
@@ -16,11 +16,11 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
         private bool CheckVersionOverride;
         private HashSet<PackageId> CentrallyManagedPackages;
 
-        public SolutionDirectoryBuildPropertyLoader(string propertyPath, NugetSearchService nugetSearchService, HashSet<PackageId> packages, bool checkVersionOverride)
+        public SolutionDirectoryBuildPropertyLoader(string propertyPath, NugetSearchService nugetSearchService, HashSet<PackageId> centrallyManagedPackages, bool checkVersionOverride)
         {
             PropertyPath = propertyPath;
             NugetSearchService = nugetSearchService;
-            CentrallyManagedPackages = packages;
+            CentrallyManagedPackages = centrallyManagedPackages;
             CheckVersionOverride = checkVersionOverride;
         }
 

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryBuildPropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryBuildPropertyLoader.cs
@@ -91,7 +91,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                         }
                     }
 
-                    if (!String.IsNullOrWhiteSpace(name) && CentrallyManagedPackages.Count > 0)
+                    if (!String.IsNullOrWhiteSpace(name) && CentrallyManagedPackages != null && CentrallyManagedPackages.Count > 0)
                     {
                        bool containsPkg =  CentrallyManagedPackages.Any(pkg => pkg.Name.Equals(name));
                        

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryPackagesPropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryPackagesPropertyLoader.cs
@@ -19,9 +19,9 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
             PropertyPath = propertyPath;
         }
         
-        public SolutionDirectoryPackagesPropertyLoader(String propertyPath, HashSet<PackageId> packageIds): this(propertyPath)
+        public SolutionDirectoryPackagesPropertyLoader(String propertyPath, HashSet<PackageId> rootCentrallyManagedPackages): this(propertyPath)
         {
-            RootCentrallyManagedPackages = packageIds;
+            RootCentrallyManagedPackages = rootCentrallyManagedPackages;
         }
 
         public HashSet<PackageId> Process()

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryPackagesPropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryPackagesPropertyLoader.cs
@@ -12,10 +12,16 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
     {
 
         private String PropertyPath;
+        private HashSet<PackageId> RootCentrallyManagedPackages;
 
         public SolutionDirectoryPackagesPropertyLoader(String propertyPath)
         {
             PropertyPath = propertyPath;
+        }
+        
+        public SolutionDirectoryPackagesPropertyLoader(String propertyPath, HashSet<PackageId> packageIds): this(propertyPath)
+        {
+            RootCentrallyManagedPackages = packageIds;
         }
 
         public HashSet<PackageId> Process()
@@ -103,6 +109,17 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                         if (propertyGroups.ContainsKey(propertyName))
                         {
                             packageVersion = propertyGroups[propertyName];
+                        }
+                    }
+
+                    if (RootCentrallyManagedPackages != null && RootCentrallyManagedPackages.Count > 0)
+                    {
+                        bool containsPkg = RootCentrallyManagedPackages.Any(pkg => pkg.Name.Equals(packageName));
+
+                        if (containsPkg)
+                        {
+                            var pkg = RootCentrallyManagedPackages.First(pkg => pkg.Name.Equals(packageName));
+                            RootCentrallyManagedPackages.Remove(pkg);
                         }
                     }
 


### PR DESCRIPTION
This PR will resolve the ticket: IDETECT-4152. If the user has enabled CPM, then the user might have removed versions from Build.props file. Earlier, I passed on packages scanned from Directory.Packages.props file to all the Native Project Inspectors but forgot to add the same logic in Directory.Build.props file. This PR will ensure that all the packages from build.props are also supported for CPM.

The changes to the files SolutionDirectoryPackagesProps file are done to accommodate if the version values are provided in child props as well. If the value is provided in child props file then we just remove the reference for the root package and add the child package to get the correct version for the sub projects as per the rules for CPM.