### PR TITLE
Fix IDETECT-4158: PackageReferences not included for non-CPM Projects

### DIFF
--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryBuildPropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryBuildPropertyLoader.cs
@@ -91,9 +91,9 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                         }
                     }
 
-                    if (!String.IsNullOrWhiteSpace(name) && CentrallyManagedPackages != null && CentrallyManagedPackages.Count > 0)
+                    if (!String.IsNullOrWhiteSpace(name))
                     {
-                       bool containsPkg =  CentrallyManagedPackages.Any(pkg => pkg.Name.Equals(name));
+                       bool containsPkg =  CentrallyManagedPackages != null && CentrallyManagedPackages.Any(pkg => pkg.Name.Equals(name));
                        
                        if (containsPkg)
                        {


### PR DESCRIPTION
With [PR15](https://github.com/blackducksoftware/detect-nuget-inspector/pull/15), the support for CPM was added in Directory.Build.props file but the condition was incorrect and it created a regression which did not include PackageReferences for non-CPM projects. I have fixed the condition to make a check for null list inside the if block to add packages for non-CPM projects.