### PR TITLE
Add Exclude Dependency Types Option in NI

### DIFF
--- a/detect-nuget-inspector/detect-nuget-inspector-tests/Inspection/Util/SolutionDirectoryPackagesPropertyLoaderTests.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/Inspection/Util/SolutionDirectoryPackagesPropertyLoaderTests.cs
@@ -21,7 +21,7 @@ namespace detect_nuget_inspector_tests.Inspection.Util
             string propertyPath = GetFilePath("Standard_Directory.Packages.props"); 
             
             var solutionDirectoryPackagesPropertyLoader =
-                new SolutionDirectoryPackagesPropertyLoader(GetFilePath(propertyPath));
+                new SolutionDirectoryPackagesPropertyLoader(GetFilePath(propertyPath), "NONE");
 
             HashSet<PackageId> packageVersions = solutionDirectoryPackagesPropertyLoader.Process();
             bool versionOverrideEnabled = solutionDirectoryPackagesPropertyLoader.GetVersionOverrideEnabled();
@@ -40,7 +40,7 @@ namespace detect_nuget_inspector_tests.Inspection.Util
             string propertyPath = GetFilePath("CPM_Disabled_Directory.Packages.props");
             
             var solutionDirectoryPackagesPropertyLoader =
-                new SolutionDirectoryPackagesPropertyLoader(GetFilePath(propertyPath));
+                new SolutionDirectoryPackagesPropertyLoader(GetFilePath(propertyPath),"NONE");
             
             StringWriter stringWriter = new StringWriter();
             Console.SetOut(stringWriter);
@@ -57,7 +57,7 @@ namespace detect_nuget_inspector_tests.Inspection.Util
             string propertyPath = GetFilePath("VersionOverride_Disabled_Directory.Packages.props");
             
             var solutionDirectoryPackagesPropertyLoader =
-                new SolutionDirectoryPackagesPropertyLoader(GetFilePath(propertyPath));
+                new SolutionDirectoryPackagesPropertyLoader(GetFilePath(propertyPath), "NONE");
             
             bool versionOverrideEnabled = solutionDirectoryPackagesPropertyLoader.GetVersionOverrideEnabled();
             
@@ -70,7 +70,7 @@ namespace detect_nuget_inspector_tests.Inspection.Util
             string propertyPath = GetFilePath("GlobalPackageReference_Directory.Packages.props");
             
             var solutionDirectoryPackagesPropertyLoader =
-                new SolutionDirectoryPackagesPropertyLoader(GetFilePath(propertyPath));
+                new SolutionDirectoryPackagesPropertyLoader(GetFilePath(propertyPath), "NONE");
 
             HashSet<PackageId> packageVersions = solutionDirectoryPackagesPropertyLoader.Process();
 

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/AppConfigKeys.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/AppConfigKeys.cs
@@ -15,5 +15,6 @@ namespace Synopsys.Detect.Nuget.Inspector.Configuration
         public const string ExcludedModules = "excluded_modules";
         public const string IncludedModules = "included_modules";
         public const string IgnoreFailures = "ignore_failure";
+        public const string ExcludedDependencyTypes = "excluded_dependency_types";
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineArgKeys.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineArgKeys.cs
@@ -16,5 +16,6 @@ namespace Synopsys.Detect.Nuget.Inspector.Configuration
         public const string ExcludedModules = AppConfigKeys.ExcludedModules;
         public const string IncludedModules = AppConfigKeys.IncludedModules;
         public const string IgnoreFailures = AppConfigKeys.IgnoreFailures;
+        public const string ExcludedDependencyTypes = AppConfigKeys.ExcludedDependencyTypes;
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineRunOptions.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineRunOptions.cs
@@ -38,6 +38,10 @@ namespace Synopsys.Detect.Nuget.Inspector.Configuration
         [AppConfigArg(AppConfigKeys.NugetConfigPath)]
         [CommandLineArg(CommandLineArgKeys.NugetConfigPath, "The path of a NuGet config file to load package sources from.")]
         public string NugetConfigPath = "";
+        
+        [AppConfigArg(AppConfigKeys.ExcludedDependencyTypes)]
+        [CommandLineArg(CommandLineArgKeys.ExcludedDependencyTypes, "The names of the dependency types to exclude from dependency node generation")]
+        public string ExcludedDependencyTypes = "";
 
         public bool ShowHelp;
         public bool Verbose;
@@ -52,6 +56,9 @@ namespace Synopsys.Detect.Nuget.Inspector.Configuration
             IgnoreFailures = String.IsNullOrEmpty(overide.IgnoreFailures) ? this.IgnoreFailures : overide.IgnoreFailures;
             PackagesRepoUrl = String.IsNullOrEmpty(overide.PackagesRepoUrl) ? this.PackagesRepoUrl : overide.PackagesRepoUrl;
             NugetConfigPath = String.IsNullOrEmpty(overide.NugetConfigPath) ? this.NugetConfigPath : overide.NugetConfigPath;
+            ExcludedDependencyTypes = String.IsNullOrEmpty(overide.ExcludedDependencyTypes)
+                ? this.ExcludedDependencyTypes
+                : overide.ExcludedDependencyTypes;
         }
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineRunOptionsParser.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineRunOptionsParser.cs
@@ -65,6 +65,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Configuration
             Console.WriteLine("Property {0} = {1}", CommandLineArgKeys.IgnoreFailures, options.IgnoreFailures);
             Console.WriteLine("Property {0} = {1}", CommandLineArgKeys.PackagesRepoUrl, options.PackagesRepoUrl);
             Console.WriteLine("Property {0} = {1}", CommandLineArgKeys.NugetConfigPath, options.NugetConfigPath);
+            Console.WriteLine("Property {0} = {1}", CommandLineArgKeys.ExcludedDependencyTypes, options.ExcludedDependencyTypes);
         }
 
         public RunOptions LoadAppSettings(string path)

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/OptionParser.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/OptionParser.cs
@@ -42,7 +42,8 @@ namespace Synopsys.Detect.Nuget.Inspector.Configuration
                     PackagesRepoUrl = parsedOptions.PackagesRepoUrl,
                     NugetConfigPath = parsedOptions.NugetConfigPath,
                     TargetPath = parsedOptions.TargetPath,
-                    Verbose = parsedOptions.Verbose
+                    Verbose = parsedOptions.Verbose,
+                    ExcludedDependencyTypes = parsedOptions.ExcludedDependencyTypes
                 };
 
                 return ParsedOptions.Succeeded(options);

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
@@ -97,10 +97,11 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
                         string versionStr = InspectorUtil.GetAttributeInformation(attributes, "Version", package);
                         string privateAssets = InspectorUtil.GetAttributeInformation(attributes, "PrivateAssets", package);
 
-                        bool isDependency =
-                            ExcludedDependencyTypeUtil.isDependencyTypeExcluded(ExcludedDependencyTypes) && !String.IsNullOrWhiteSpace(privateAssets);
+                        bool isDevDependency = ExcludedDependencyTypeUtil.isDependencyTypeExcluded(ExcludedDependencyTypes,"DEV");
+                                           
+                        bool excludeDevDependency = isDevDependency && !String.IsNullOrWhiteSpace(privateAssets);
                         
-                        if (!String.IsNullOrWhiteSpace(include) && !isDependency)
+                        if (!String.IsNullOrWhiteSpace(include) && !excludeDevDependency)
                         {
                             bool containsPkg = CentrallyManagedPackages != null && CentrallyManagedPackages.Any(pkg => pkg.Name.Equals(include));
                             

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Xml;
 using Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget;
+using Synopsys.Detect.Nuget.Inspector.Inspection.Util;
 using Synopsys.Detect.Nuget.Inspector.Model;
 
 namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
@@ -15,14 +16,16 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
         private NugetSearchService NugetSearchService;
         private HashSet<PackageId> CentrallyManagedPackages;
         private bool CheckVersionOverride;
+        private string ExcludedDependencyTypes;
 
-        public ProjectXmlResolver(string projectPath, NugetSearchService nugetSearchService)
+        public ProjectXmlResolver(string projectPath, NugetSearchService nugetSearchService, string excludedDependencyTypes)
         {
             ProjectPath = projectPath;
             NugetSearchService = nugetSearchService;
+            ExcludedDependencyTypes = excludedDependencyTypes;
         }
         
-        public ProjectXmlResolver(string projectPath, NugetSearchService nugetSearchService, HashSet<PackageId> centrallyManagedPackages, bool checkVersionOverride): this(projectPath, nugetSearchService)
+        public ProjectXmlResolver(string projectPath, NugetSearchService nugetSearchService, string excludedDependencyTypes, HashSet<PackageId> centrallyManagedPackages, bool checkVersionOverride): this(projectPath, nugetSearchService, excludedDependencyTypes)
         {
             CentrallyManagedPackages = centrallyManagedPackages;
             CheckVersionOverride = checkVersionOverride;
@@ -89,22 +92,25 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
                     XmlAttributeCollection attributes = package.Attributes;
                     if (attributes != null)
                     {
-                        XmlAttribute include = attributes["Include"];
-                        
-                        string versionOverrideStr = GetVersionInformation(attributes, "VersionOverride", package);
-                        string versionStr = GetVersionInformation(attributes, "Version", package);
+                        string include = InspectorUtil.GetAttributeInformation(attributes, "Include", package);
+                        string versionOverrideStr = InspectorUtil.GetAttributeInformation(attributes, "VersionOverride", package);
+                        string versionStr = InspectorUtil.GetAttributeInformation(attributes, "Version", package);
+                        string privateAssets = InspectorUtil.GetAttributeInformation(attributes, "PrivateAssets", package);
 
-                        if (include != null)
+                        bool isDependency =
+                            ExcludedDependencyTypeUtil.isDependencyTypeExcluded(ExcludedDependencyTypes) && !String.IsNullOrWhiteSpace(privateAssets);
+                        
+                        if (!String.IsNullOrWhiteSpace(include) && !isDependency)
                         {
-                            bool containsPkg = CentrallyManagedPackages != null && CentrallyManagedPackages.Any(pkg => pkg.Name.Equals(include.Value));
+                            bool containsPkg = CentrallyManagedPackages != null && CentrallyManagedPackages.Any(pkg => pkg.Name.Equals(include));
                             
                             if (containsPkg)
                             {
-                                PackageId pkg = CentrallyManagedPackages.First(pkg => pkg.Name.Equals(include.Value));
+                                PackageId pkg = CentrallyManagedPackages.First(pkg => pkg.Name.Equals(include));
                                 
                                 if (!String.IsNullOrWhiteSpace(versionOverrideStr) && CheckVersionOverride)
                                 { 
-                                    addNugetDependency(tree, include.Value, versionOverrideStr);
+                                    addNugetDependency(tree, include, versionOverrideStr);
                                 }
                                 else if (!String.IsNullOrWhiteSpace(versionOverrideStr) && !CheckVersionOverride)
                                 {
@@ -112,14 +118,14 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
                                 }
                                 else
                                 {
-                                    addNugetDependency(tree, include.Value, pkg.Version);
+                                    addNugetDependency(tree, include, pkg.Version);
                                 }
                             }
                             else
                             {
                                 if (!String.IsNullOrWhiteSpace(versionStr))
                                 {
-                                    addNugetDependency(tree, include.Value, versionStr);
+                                    addNugetDependency(tree, include, versionStr);
                                 }
                             }
                         }
@@ -139,31 +145,6 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
             }
 
             return result;
-        }
-        
-        private string GetVersionInformation(XmlAttributeCollection attributes, string checkString, XmlNode package)
-        {
-            string versionStr = null;
-            
-            XmlAttribute version = attributes[checkString];
-
-            if (version == null)
-            {
-                foreach (XmlNode node in package.ChildNodes)
-                {
-                    if (node.Name == checkString)
-                    {
-                        versionStr = node.InnerXml;
-                        break;
-                    }
-                }
-            }
-            else
-            {
-                versionStr = version.Value;
-            }
-            
-            return versionStr;
         }
 
         private void addNugetDependency(NugetTreeResolver tree, string include, string version)

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectionOptions.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectionOptions.cs
@@ -16,5 +16,6 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection
         public string ExcludedModules { get; set; } = "";
         public string IncludedModules { get; set; } = "";
         public bool IgnoreFailure { get; set; } = false;
+        public string ExcludedDependencyTypes { get; set; } = "NONE";
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
@@ -168,7 +168,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                 {
                     Console.WriteLine("Using Central Package Management: " + Options.DirectoryPackagesPropsPath);
                     var packagesPropertyLoader =
-                        new SolutionDirectoryPackagesPropertyLoader(Options.DirectoryPackagesPropsPath, CentrallyManagedPackages);
+                        new SolutionDirectoryPackagesPropertyLoader(Options.DirectoryPackagesPropsPath, Options.ExcludedDependencyTypes, CentrallyManagedPackages);
                     projectNode.PackagePropertyPackages = packagesPropertyLoader.Process();
                     projectNode.Dependencies = packagesPropertyLoader.GetGlobalPackageReferences().ToList();
                 }
@@ -210,11 +210,11 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                     ProjectReferenceResolver referenceResolver;
                     if (CentrallyManagedPackages != null && CentrallyManagedPackages.Count > 0)
                     {
-                        referenceResolver = new ProjectReferenceResolver(Options.TargetPath, NugetService, CentrallyManagedPackages, CheckVersionOverride);
+                        referenceResolver = new ProjectReferenceResolver(Options.TargetPath, NugetService, Options.ExcludedDependencyTypes, CentrallyManagedPackages, CheckVersionOverride);
                     }
                     else
                     {
-                        referenceResolver = new ProjectReferenceResolver(Options.TargetPath, NugetService);
+                        referenceResolver = new ProjectReferenceResolver(Options.TargetPath, NugetService, Options.ExcludedDependencyTypes);
                     }
                     var projectReferencesResult = referenceResolver.Process();
                     if (projectReferencesResult.Success)
@@ -229,11 +229,11 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                         ProjectXmlResolver xmlResolver;
                         if (CentrallyManagedPackages != null && CentrallyManagedPackages.Count > 0)
                         {
-                            xmlResolver = new ProjectXmlResolver(Options.TargetPath, NugetService, CentrallyManagedPackages, CheckVersionOverride);
+                            xmlResolver = new ProjectXmlResolver(Options.TargetPath, NugetService, Options.ExcludedDependencyTypes, CentrallyManagedPackages, CheckVersionOverride);
                         }
                         else
                         {
-                            xmlResolver = new ProjectXmlResolver(Options.TargetPath, NugetService);
+                            xmlResolver = new ProjectXmlResolver(Options.TargetPath, NugetService, Options.ExcludedDependencyTypes);
                         }
                         var xmlResult = xmlResolver.Process();
                         projectNode.Version = xmlResult.ProjectVersion;

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspectorOptions.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspectorOptions.cs
@@ -19,6 +19,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
             this.ExcludedModules = old.ExcludedModules;
             this.IncludedModules = old.IncludedModules;
             this.IgnoreFailure = old.IgnoreFailure;
+            this.ExcludedDependencyTypes = old.ExcludedDependencyTypes;
         }
 
         public string ProjectName { get; set; }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
@@ -81,7 +81,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                 if (solutionDirectoryPackagesPropertyExists)
                 {
                     Console.WriteLine("Using solution directory packages property file: " + solutionDirectoryPackagesPropertyPath);
-                    var packagePropertyLoader = new SolutionDirectoryPackagesPropertyLoader(solutionDirectoryPackagesPropertyPath);
+                    var packagePropertyLoader = new SolutionDirectoryPackagesPropertyLoader(solutionDirectoryPackagesPropertyPath, Options.ExcludedDependencyTypes);
                     packagesProperty = packagePropertyLoader.Process();
                     globalPackageReferences = packagePropertyLoader.GetGlobalPackageReferences();
                     checkVersionOverride = packagePropertyLoader.GetVersionOverrideEnabled();
@@ -94,7 +94,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                 if (solutionDirectoryBuildPropertyExists)
                 {
                     Console.WriteLine("Using solution directory build property file: " + solutionDirectoryBuildPropertyPath);
-                    var propertyLoader = new SolutionDirectoryBuildPropertyLoader(solutionDirectoryBuildPropertyPath, NugetService,packagesProperty, checkVersionOverride);
+                    var propertyLoader = new SolutionDirectoryBuildPropertyLoader(solutionDirectoryBuildPropertyPath, NugetService,packagesProperty, checkVersionOverride, Options.ExcludedDependencyTypes);
                     buildPropertyPackages = propertyLoader.Process();
                     checkVersionOverride = propertyLoader.GetVersionOverrideEnabled();
                 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspectorOptions.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspectorOptions.cs
@@ -19,6 +19,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
             this.ExcludedModules = old.ExcludedModules;
             this.IncludedModules = old.IncludedModules;
             this.IgnoreFailure = old.IgnoreFailure;
+            this.ExcludedDependencyTypes = old.ExcludedDependencyTypes;
         }
 
         public string SolutionName { get; set; }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/ExcludedDependencyTypeUtil.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/ExcludedDependencyTypeUtil.cs
@@ -3,10 +3,10 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Util
 
     static class ExcludedDependencyTypeUtil
     {
-        public static bool isDependencyTypeExcluded(String excludedDependencyTypes)
+        public static bool isDependencyTypeExcluded(String excludedDependencyTypes, String dependencyType)
         {
 
-            if (excludedDependencyTypes == "DEV")
+            if (excludedDependencyTypes.Equals(dependencyType))
             {
                 return true;
             }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/ExcludedDependencyTypeUtil.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/ExcludedDependencyTypeUtil.cs
@@ -1,0 +1,17 @@
+namespace Synopsys.Detect.Nuget.Inspector.Inspection.Util
+{
+
+    static class ExcludedDependencyTypeUtil
+    {
+        public static bool isDependencyTypeExcluded(String excludedDependencyTypes)
+        {
+
+            if (excludedDependencyTypes == "DEV")
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/InspectorUtil.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/InspectorUtil.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using static Synopsys.Detect.Nuget.Inspector.Inspection.Util.AssemblyInfoVersionParser;
+using System.Xml;
 
 namespace Synopsys.Detect.Nuget.Inspector.Inspection.Util
 {
@@ -60,6 +61,31 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Util
             }
 
             return null;
+        }
+        
+        public static string GetAttributeInformation(XmlAttributeCollection attributes, string checkString, XmlNode package)
+        {
+            string versionStr = null;
+            
+            XmlAttribute version = attributes[checkString];
+
+            if (version == null)
+            {
+                foreach (XmlNode node in package.ChildNodes)
+                {
+                    if (node.Name == checkString)
+                    {
+                        versionStr = node.InnerXml;
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                versionStr = version.Value;
+            }
+            
+            return versionStr;
         }
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/InspectorUtil.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/InspectorUtil.cs
@@ -65,27 +65,27 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Util
         
         public static string GetAttributeInformation(XmlAttributeCollection attributes, string checkString, XmlNode package)
         {
-            string versionStr = null;
+            string attributeStr = null;
             
-            XmlAttribute version = attributes[checkString];
+            XmlAttribute attribute = attributes[checkString];
 
-            if (version == null)
+            if (attribute == null)
             {
                 foreach (XmlNode node in package.ChildNodes)
                 {
                     if (node.Name == checkString)
                     {
-                        versionStr = node.InnerXml;
+                        attributeStr = node.InnerXml;
                         break;
                     }
                 }
             }
             else
             {
-                versionStr = version.Value;
+                attributeStr = attribute.Value;
             }
             
-            return versionStr;
+            return attributeStr;
         }
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryBuildPropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryBuildPropertyLoader.cs
@@ -65,10 +65,11 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                     string versionStr = InspectorUtil.GetAttributeInformation(attributes, "Version", packageNode);
                     string privateAssets = InspectorUtil.GetAttributeInformation(attributes, "PrivateAssets", packageNode);
 
-                    bool isDependency =
-                        ExcludedDependencyTypeUtil.isDependencyTypeExcluded(ExcludedDependencyTypes) && !String.IsNullOrWhiteSpace(privateAssets);
+                    bool isDevDependency = ExcludedDependencyTypeUtil.isDependencyTypeExcluded(ExcludedDependencyTypes,"DEV");
+                                           
+                    bool excludeDevDependency = isDevDependency && !String.IsNullOrWhiteSpace(privateAssets);
 
-                    if (!String.IsNullOrWhiteSpace(name) && !isDependency)
+                    if (!String.IsNullOrWhiteSpace(name) && !excludeDevDependency)
                     {
                        bool containsPkg =  CentrallyManagedPackages != null && CentrallyManagedPackages.Any(pkg => pkg.Name.Equals(name));
                        

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryBuildPropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryBuildPropertyLoader.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Xml;
 using Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget;
+using Synopsys.Detect.Nuget.Inspector.Inspection.Util;
 using Synopsys.Detect.Nuget.Inspector.Model;
 
 namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
@@ -15,13 +16,15 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
         private NugetSearchService NugetSearchService;
         private bool CheckVersionOverride;
         private HashSet<PackageId> CentrallyManagedPackages;
+        private string ExcludedDependencyTypes;
 
-        public SolutionDirectoryBuildPropertyLoader(string propertyPath, NugetSearchService nugetSearchService, HashSet<PackageId> centrallyManagedPackages, bool checkVersionOverride)
+        public SolutionDirectoryBuildPropertyLoader(string propertyPath, NugetSearchService nugetSearchService, HashSet<PackageId> centrallyManagedPackages, bool checkVersionOverride, string excludedDependencyTypes)
         {
             PropertyPath = propertyPath;
             NugetSearchService = nugetSearchService;
             CentrallyManagedPackages = centrallyManagedPackages;
             CheckVersionOverride = checkVersionOverride;
+            ExcludedDependencyTypes = excludedDependencyTypes;
         }
 
         public HashSet<PackageId> Process()
@@ -56,42 +59,16 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                 if (packageNode.NodeType != XmlNodeType.Comment)
                 {
                     XmlAttributeCollection attributes = packageNode.Attributes;
-                    string name = null;
-                    string version = null;
-                    string versionOverride = null;
-                    foreach (XmlAttribute at in attributes)
-                    {
-                        if (at.LocalName.Contains("Include"))
-                        {
-                            name = at.Value;
-                        } 
-                        else if (at.LocalName.Contains("Version"))
-                        {
-                            version = at.Value;
-                        }
-                        else if (at.LocalName.Contains("VersionOverride"))
-                        {
-                            versionOverride = at.Value;
-                        }
-                    }
-                    
-                    if (String.IsNullOrWhiteSpace(version) && String.IsNullOrWhiteSpace(versionOverride))
-                    {
-                        foreach (XmlNode node in packageNode.ChildNodes)
-                        {
-                            if (node.Name == "Version")
-                            {
-                                version = node.InnerXml;
-                            }
-                            else if(node.Name == "VersionOverride")
-                            {
-                                versionOverride = node.InnerXml;
-                                break;
-                            }
-                        }
-                    }
 
-                    if (!String.IsNullOrWhiteSpace(name))
+                    string name = InspectorUtil.GetAttributeInformation(attributes, "Include", packageNode);
+                    string versionOverrideStr = InspectorUtil.GetAttributeInformation(attributes, "VersionOverride", packageNode);
+                    string versionStr = InspectorUtil.GetAttributeInformation(attributes, "Version", packageNode);
+                    string privateAssets = InspectorUtil.GetAttributeInformation(attributes, "PrivateAssets", packageNode);
+
+                    bool isDependency =
+                        ExcludedDependencyTypeUtil.isDependencyTypeExcluded(ExcludedDependencyTypes) && !String.IsNullOrWhiteSpace(privateAssets);
+
+                    if (!String.IsNullOrWhiteSpace(name) && !isDependency)
                     {
                        bool containsPkg =  CentrallyManagedPackages != null && CentrallyManagedPackages.Any(pkg => pkg.Name.Equals(name));
                        
@@ -99,11 +76,11 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                        {
                            var pkg = CentrallyManagedPackages.First(pkg => pkg.Name.Equals(name));
                            
-                           if (!String.IsNullOrWhiteSpace(versionOverride) && (CheckVersionOverride || GetVersionOverrideEnabled()))
+                           if (!String.IsNullOrWhiteSpace(versionOverrideStr) && (CheckVersionOverride || GetVersionOverrideEnabled()))
                            {
-                               packageReferences.Add(new PackageId(name, versionOverride));
+                               packageReferences.Add(new PackageId(name, versionOverrideStr));
                            }
-                           else if (!String.IsNullOrWhiteSpace(versionOverride) && !CheckVersionOverride)
+                           else if (!String.IsNullOrWhiteSpace(versionOverrideStr) && !CheckVersionOverride)
                            {
                                Console.WriteLine("The Central Package Version Overriding is disabled, please enable version override or remove VersionOverride tags from project");
                            }
@@ -114,9 +91,9 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                        }
                        else
                        {
-                           if (!String.IsNullOrWhiteSpace(version))
+                           if (!String.IsNullOrWhiteSpace(versionStr))
                            {
-                               packageReferences.Add(new PackageId(name, version));
+                               packageReferences.Add(new PackageId(name, versionStr));
                            }
                        }
                     }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryPackagesPropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryPackagesPropertyLoader.cs
@@ -83,8 +83,9 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                     string packageVersion = InspectorUtil.GetAttributeInformation(attributes,"Version", packageNode);
                     string privateAssets = InspectorUtil.GetAttributeInformation(attributes,"PrivateAssets", packageNode);
 
-                    bool isDependency = !String.IsNullOrWhiteSpace(privateAssets) &&
-                                        ExcludedDependencyTypeUtil.isDependencyTypeExcluded(ExcludedDependencyTypes);
+                    bool isDevDependency = ExcludedDependencyTypeUtil.isDependencyTypeExcluded(ExcludedDependencyTypes,"DEV");
+                                           
+                    bool excludeDevDependency = isDevDependency && !String.IsNullOrWhiteSpace(privateAssets);
 
                     if (!String.IsNullOrWhiteSpace(packageVersion) && packageVersion.Contains("$("))
                     {
@@ -106,7 +107,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                         }
                     }
 
-                    if (!String.IsNullOrWhiteSpace(packageName) && !String.IsNullOrWhiteSpace(packageVersion) && !isDependency)
+                    if (!String.IsNullOrWhiteSpace(packageName) && !String.IsNullOrWhiteSpace(packageVersion) && !excludeDevDependency)
                     {
                         packages.Add(new PackageId(packageName, packageVersion));
                     }


### PR DESCRIPTION
This PR adds an option for users to exclude particular dependency types from BOM to NI as defined in IDETECT-4140. There is a new property added in Detect which would be evaluated in NI to check if the user wants to exclude dependency types and those packages or dependencies will not be added to the dependency list passed on to Detect.

Along with the addition of the above option, the PR also contains some refactoring of code. The GetAttributeInformation method was added in Utils class to get the attribute's value in every Xml Parser in NI. 