### PR TITLE
Exclude dev dependencies from packages.config

### DIFF
--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/PackagesConfig/PackagesConfigResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/PackagesConfig/PackagesConfigResolver.cs
@@ -49,7 +49,7 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.PackagesConfig
             PackagesConfigReader reader = new PackagesConfigReader(stream);
             List<PackageReference> packages = reader.GetPackages().ToList();
             
-            bool isDevDependency = ExcludedDependencyTypeUtil.isDependencyTypeExcluded(ExcludedDependencyTypes,"DEV");
+            bool isDevDependencyTypeExcluded = ExcludedDependencyTypeUtil.isDependencyTypeExcluded(ExcludedDependencyTypes,"DEV");
 
             var dependencies = new List<NugetDependency>();
 
@@ -60,7 +60,7 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.PackagesConfig
                 var versionRange = new NuGet.Versioning.VersionRange(version, true, version, true);
                 var framework = NuGet.Frameworks.NuGetFramework.Parse(packageRef.TargetFramework.Framework);
 
-                bool excludeDevDependency = isDevDependency && packageRef.IsDevelopmentDependency;
+                bool excludeDevDependency = isDevDependencyTypeExcluded && packageRef.IsDevelopmentDependency;
                 
                 if (!excludeDevDependency)
                 {

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/PackagesConfig/PackagesConfigResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/PackagesConfig/PackagesConfigResolver.cs
@@ -61,8 +61,7 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.PackagesConfig
                 var framework = NuGet.Frameworks.NuGetFramework.Parse(packageRef.TargetFramework.Framework);
 
                 bool excludeDevDependency = isDevDependency && packageRef.IsDevelopmentDependency;
-
-                //TODO: Check that this works.
+                
                 if (!excludeDevDependency)
                 {
                     var dep = new NugetDependency(componentName, versionRange, framework);

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectReferenceResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectReferenceResolver.cs
@@ -50,9 +50,9 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
                     var versionOverrideMetaData = reference.Metadata.Where(meta => meta.Name == "VersionOverride").FirstOrDefault();
                     var privateAssetsMetaData = reference.Metadata.Where(meta => meta.Name == "PrivateAssets").FirstOrDefault();
 
-                    bool isDevDependency = ExcludedDependencyTypeUtil.isDependencyTypeExcluded(ExcludedDependencyTypes,"DEV");
+                    bool isDevDependencyTypeExcluded = ExcludedDependencyTypeUtil.isDependencyTypeExcluded(ExcludedDependencyTypes,"DEV");
 
-                    bool excludeDevDependency = isDevDependency && privateAssetsMetaData != null;
+                    bool excludeDevDependency = isDevDependencyTypeExcluded && privateAssetsMetaData != null;
 
                     if (!excludeDevDependency)
                     {

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
@@ -97,9 +97,9 @@ namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
                         string versionStr = InspectorUtil.GetAttributeInformation(attributes, "Version", package);
                         string privateAssets = InspectorUtil.GetAttributeInformation(attributes, "PrivateAssets", package);
 
-                        bool isDevDependency = ExcludedDependencyTypeUtil.isDependencyTypeExcluded(ExcludedDependencyTypes,"DEV");
+                        bool isDevDependencyTypeExcluded = ExcludedDependencyTypeUtil.isDependencyTypeExcluded(ExcludedDependencyTypes,"DEV");
                                            
-                        bool excludeDevDependency = isDevDependency && !String.IsNullOrWhiteSpace(privateAssets);
+                        bool excludeDevDependency = isDevDependencyTypeExcluded && !String.IsNullOrWhiteSpace(privateAssets);
                         
                         if (!String.IsNullOrWhiteSpace(include) && !excludeDevDependency)
                         {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
@@ -175,7 +175,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                 else if (packagesConfigExists)
                 {
                     Console.WriteLine("Using packages config: " + Options.PackagesConfigPath);
-                    var packagesConfigResolver = new PackagesConfigResolver(Options.PackagesConfigPath, NugetService);
+                    var packagesConfigResolver = new PackagesConfigResolver(Options.PackagesConfigPath, NugetService, Options.ExcludedDependencyTypes);
                     var packagesConfigResult = packagesConfigResolver.Process();
                     projectNode.Packages = packagesConfigResult.Packages;
                     projectNode.Dependencies = packagesConfigResult.Dependencies;

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryBuildPropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryBuildPropertyLoader.cs
@@ -65,9 +65,9 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                     string versionStr = InspectorUtil.GetAttributeInformation(attributes, "Version", packageNode);
                     string privateAssets = InspectorUtil.GetAttributeInformation(attributes, "PrivateAssets", packageNode);
 
-                    bool isDevDependency = ExcludedDependencyTypeUtil.isDependencyTypeExcluded(ExcludedDependencyTypes,"DEV");
+                    bool isDevDependencyTypeExcluded = ExcludedDependencyTypeUtil.isDependencyTypeExcluded(ExcludedDependencyTypes,"DEV");
                                            
-                    bool excludeDevDependency = isDevDependency && !String.IsNullOrWhiteSpace(privateAssets);
+                    bool excludeDevDependency = isDevDependencyTypeExcluded && !String.IsNullOrWhiteSpace(privateAssets);
 
                     if (!String.IsNullOrWhiteSpace(name) && !excludeDevDependency)
                     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryPackagesPropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryPackagesPropertyLoader.cs
@@ -83,9 +83,9 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                     string packageVersion = InspectorUtil.GetAttributeInformation(attributes,"Version", packageNode);
                     string privateAssets = InspectorUtil.GetAttributeInformation(attributes,"PrivateAssets", packageNode);
 
-                    bool isDevDependency = ExcludedDependencyTypeUtil.isDependencyTypeExcluded(ExcludedDependencyTypes,"DEV");
+                    bool isDevDependencyTypeExcluded = ExcludedDependencyTypeUtil.isDependencyTypeExcluded(ExcludedDependencyTypes,"DEV");
                                            
-                    bool excludeDevDependency = isDevDependency && !String.IsNullOrWhiteSpace(privateAssets);
+                    bool excludeDevDependency = isDevDependencyTypeExcluded && !String.IsNullOrWhiteSpace(privateAssets);
 
                     if (!String.IsNullOrWhiteSpace(packageVersion) && packageVersion.Contains("$("))
                     {


### PR DESCRIPTION
This PR will add support for excluding dev dependencies from packages.config file. This will go as part of ticket IDETECT-4140 along with the other file supports already added for 9.4.0. 