### PR TITLE
Fix IDETECT-4207: Changed handling of multiple props file location

### DIFF
--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
@@ -132,7 +132,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                                     parentPath =
                                         parentPath.Substring(0, OperatingSystem.IsWindows() ? parentPath.LastIndexOf("\\") : parentPath.LastIndexOf("/"));
                                     string checkFile = Path.Combine(parentPath, projectRelativePath);
-                                    if (parentPath.Equals(Path.GetPathRoot(solutionDirectory)))
+                                    if (parentPath.Equals(Path.GetPathRoot(solutionDirectory)) || parentPath.Equals(""))
                                     {
                                         Console.WriteLine("The Path provided in the sln file is wrong, will skip parsing over this file");
                                         break;

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/ProjectFile.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/ProjectFile.cs
@@ -30,7 +30,10 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
             }
             else if(rightSide.Contains("Directory.Packages.props"))
             {
-                rightSide = rightSide.Split("..\\")[1];
+                if (rightSide.Contains("..\\"))
+                {
+                    rightSide = rightSide.Split("..\\")[1];
+                }
                 file.Path = OperatingSystem.IsWindows() ? rightSide : rightSide.Replace("\\", "/");
                 return file;
             }


### PR DESCRIPTION
This PR will handle the bug mentioned in IDETECT-4207. Certainly while developing this, the regular file pattern system was not taken into account ( E.g. src\Directory.Packages.props = src\Directory.Packages.props) and as a result the code only worked for UNIX file patterns such as  (..\sample\Directory.Packages.props = ..\sample\Directory.Packages.props) file. 

With this change, now the code will handle both the type of files without throwing IndexOutOfRangeException. While searching the github for lot of these kind of projects, it looks like these are the only two ways of mentioning the props file in sln file.