### PR TITLE
Fix IDETECT-4207: ArgumentOutOfIndexException in Windows

### DIFF
--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
@@ -130,7 +130,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                                 while (fileNotFound)
                                 {
                                     string checkFile = Path.Combine(parentPath, projectRelativePath);
-                                    if (parentPath.Equals(Path.GetPathRoot(solutionDirectory)) || parentPath.Equals(""))
+                                    if (parentPath.Equals("") || parentPath.Equals(Path.GetPathRoot(solutionDirectory)))
                                     {
                                         Console.WriteLine("The Path provided in the sln file is wrong, will skip parsing over this file");
                                         break;

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
@@ -129,14 +129,14 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                                 bool fileNotFound = true;
                                 while (fileNotFound)
                                 {
-                                    parentPath =
-                                        parentPath.Substring(0, OperatingSystem.IsWindows() ? parentPath.LastIndexOf("\\") : parentPath.LastIndexOf("/"));
                                     string checkFile = Path.Combine(parentPath, projectRelativePath);
                                     if (parentPath.Equals(Path.GetPathRoot(solutionDirectory)) || parentPath.Equals(""))
                                     {
                                         Console.WriteLine("The Path provided in the sln file is wrong, will skip parsing over this file");
                                         break;
                                     }
+                                    parentPath =
+                                        parentPath.Substring(0, OperatingSystem.IsWindows() ? parentPath.LastIndexOf("\\") : parentPath.LastIndexOf("/"));
                                     directoryPackagesExists = File.Exists(checkFile);
                                     fileNotFound = !directoryPackagesExists;
                                     projectPath = checkFile;


### PR DESCRIPTION
This PR will fix the ArgumentOutOfIndexException in windows machines. The cause of the issue was invoking the substring method on variable before making the check if was null or empty string. 