### PR TITLE
Use SetGlobalProperty for updating $(Configuration)

### DIFF
--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
@@ -279,7 +279,7 @@ namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
                 if (configurations == null) configurations = new List<string>();
                 foreach (var config in configurations)
                 {
-                    proj.SetProperty("Configuration", config);
+                    proj.SetGlobalProperty("Configuration", config);
                     proj.ReevaluateIfNecessary();
                     var path = proj.GetPropertyValue("OutputPath");
                     var fullPath = PathUtil.Combine(proj.DirectoryPath, path);


### PR DESCRIPTION
Config property is not used for output path calculation when output path is overriden.

To reproduce it, use next project:
* Directory.Build.props:
```xml
<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
  <PropertyGroup>
    <ProjPart Condition="'$(ProjPart)' == ''">$([MSBuild]::MakeRelative($(MSBuildThisFileDirectory),$(MSBuildProjectDirectory)))\$([System.IO.Path]::GetFileNameWithoutExtension($(MSBuildProjectFile)))</ProjPart>
    <OutputPath>..\..\output\bin\$(Configuration)\$(ProjPart)</OutputPath>
  </PropertyGroup>
</Project>
```
* Normal.csproj:
```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFrameworks>net8.0;net7.0</TargetFrameworks>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>
    <JsonVersion>13.0.3</JsonVersion>
  </PropertyGroup>

  <ItemGroup>
    <PackageReference Include="Newtonsoft.Json" Version="$(JsonVersion)" />
  </ItemGroup>

</Project>
```
* Program.cs
```c#
Console.WriteLine("Hello, World!");
```

Using SetGlobalProperty fixes the issue