### PR TITLE
Update synopsys references to blackduck

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
 ext.dotNetExec = project.hasProperty('dotNetExec') ? project.getProperty('dotNetExec') : 'dotnet6'
 
-group 'com.synopsys.integration'
+group 'com.blackduck.integration'
 version = '1.3.1-SNAPSHOT'
 
 apply plugin: 'com.synopsys.integration.solution'

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Nuget/Resolver/NugetLockFileResolverTest.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Nuget/Resolver/NugetLockFileResolverTest.cs
@@ -1,4 +1,4 @@
-﻿namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget.Test
+﻿namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget.Test
 {
     [TestClass]
     public class NugetLockFileResolverTest

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Project/ProjectJsonResolverTests.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/DependencyResolution/Project/ProjectJsonResolverTests.cs
@@ -1,6 +1,6 @@
 using Newtonsoft.Json.Linq;
 
-namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project.Test;
+namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Project.Test;
 
 [TestClass]
 public class ProjectJsonResolverTests

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/Inspection/Util/SolutionDirectoryPackagesPropertyLoaderTests.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/Inspection/Util/SolutionDirectoryPackagesPropertyLoaderTests.cs
@@ -1,6 +1,6 @@
 using System.Security.Policy;
-using Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors;
-using Synopsys.Detect.Nuget.Inspector.Model;
+using Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors;
+using Blackduck.Detect.Nuget.Inspector.Model;
 
 namespace detect_nuget_inspector_tests.Inspection.Util
 {

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/AppConfigArgAttribute.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/AppConfigArgAttribute.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.Configuration
+namespace Blackduck.Detect.Nuget.Inspector.Configuration
 {
     class AppConfigArgAttribute : Attribute
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/AppConfigKeys.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/AppConfigKeys.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.Configuration
+namespace Blackduck.Detect.Nuget.Inspector.Configuration
 {
     public static class AppConfigKeys
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineArgAttribute.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineArgAttribute.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.Configuration
+namespace Blackduck.Detect.Nuget.Inspector.Configuration
 {
     class CommandLineArgAttribute : Attribute
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineArgKeys.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineArgKeys.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.Configuration
+namespace Blackduck.Detect.Nuget.Inspector.Configuration
 {
     public static class CommandLineArgKeys
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineRunOptions.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineRunOptions.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.Configuration
+namespace Blackduck.Detect.Nuget.Inspector.Configuration
 {
     public class RunOptions
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineRunOptionsParser.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineRunOptionsParser.cs
@@ -7,7 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Mono.Options;
 
-namespace Synopsys.Detect.Nuget.Inspector.Configuration
+namespace Blackduck.Detect.Nuget.Inspector.Configuration
 {
     class CommandLineRunOptionsParser
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/OptionParser.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/OptionParser.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Synopsys.Detect.Nuget.Inspector.Inspection;
+using Blackduck.Detect.Nuget.Inspector.Inspection;
 
-namespace Synopsys.Detect.Nuget.Inspector.Configuration
+namespace Blackduck.Detect.Nuget.Inspector.Configuration
 {
     public class OptionParser
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/DependencyResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/DependencyResolver.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution
+namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution
 {
     interface DependencyResolver
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/DependencyResult.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/DependencyResult.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution
+namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution
 {
     public class DependencyResult
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/NugetDependency.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/NugetDependency.cs
@@ -7,7 +7,7 @@ using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 
-namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget
+namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget
 {
     public class NugetDependency
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/NugetFramework.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/NugetFramework.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget
+namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget
 {
     public class NugetFramework
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/NugetLogger.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/NugetLogger.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using NuGet.Common;
 
-namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget
+namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget
 {
     // For the NuGet API
     public class NugetLogger : NuGet.Common.ILogger

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/NugetSearchService.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/NugetSearchService.cs
@@ -11,7 +11,7 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 
-namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget
+namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget
 {
     public class NugetSearchService
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/Resolver/NugetFlatResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/Resolver/NugetFlatResolver.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 
-namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget
+namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget
 {
     //Given a list of dependencies, resolve them such that all packages are shared in a flat list
     //Essentially means that no nodes in the tree that refer to the same package may have different versions.

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/Resolver/NugetLockFileResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/Resolver/NugetLockFileResolver.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget
+namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget
 {
     public class NugetLockFileResolver
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/Resolver/NugetTreeResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/Resolver/NugetTreeResolver.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
 
-namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget
+namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget
 {
     public class NugetTreeResolver
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/PackagesConfig/PackagesConfigResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/PackagesConfig/PackagesConfigResolver.cs
@@ -4,10 +4,10 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NuGet.Packaging;
-using Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget;
-using Synopsys.Detect.Nuget.Inspector.Inspection.Util;
+using Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget;
+using Blackduck.Detect.Nuget.Inspector.Inspection.Util;
 
-namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.PackagesConfig
+namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.PackagesConfig
 {
     class PackagesConfigResolver : DependencyResolver
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectAssetsJsonResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectAssetsJsonResolver.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget;
+using Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget;
 
-namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
+namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Project
 {
     class ProjectAssetsJsonResolver : DependencyResolver
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectJsonResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectJsonResolver.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json.Linq;
 using NuGet.LibraryModel;
 using NuGet.ProjectModel;
 
-namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
+namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Project
 {
     public class ProjectJsonResolver : DependencyResolver
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectLockJsonResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectLockJsonResolver.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget;
+using Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget;
 
-namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
+namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Project
 {
     class ProjectLockJsonResolver : DependencyResolver
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectReferenceResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectReferenceResolver.cs
@@ -5,11 +5,11 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Exceptions;
-using Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget;
-using Synopsys.Detect.Nuget.Inspector.Inspection.Util;
-using Synopsys.Detect.Nuget.Inspector.Model;
+using Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget;
+using Blackduck.Detect.Nuget.Inspector.Inspection.Util;
+using Blackduck.Detect.Nuget.Inspector.Model;
 
-namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
+namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Project
 {
     class ProjectReferenceResolver : DependencyResolver
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Xml;
-using Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget;
-using Synopsys.Detect.Nuget.Inspector.Inspection.Util;
-using Synopsys.Detect.Nuget.Inspector.Model;
+using Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget;
+using Blackduck.Detect.Nuget.Inspector.Inspection.Util;
+using Blackduck.Detect.Nuget.Inspector.Model;
 
-namespace Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project
+namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Project
 {
     class ProjectXmlResolver : DependencyResolver
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/IInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/IInspector.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.Inspection
+namespace Blackduck.Detect.Nuget.Inspector.Inspection
 {
     interface IInspector
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectionOptions.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectionOptions.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.Inspection
+namespace Blackduck.Detect.Nuget.Inspector.Inspection
 {
     public class InspectionOptions
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectionResult.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectionResult.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Synopsys.Detect.Nuget.Inspector.Model;
+using Blackduck.Detect.Nuget.Inspector.Model;
 
-namespace Synopsys.Detect.Nuget.Inspector.Inspection
+namespace Blackduck.Detect.Nuget.Inspector.Inspection
 {
     class InspectionResult
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectorDispatch.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectorDispatch.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget;
-using Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors;
-using Synopsys.Detect.Nuget.Inspector.Inspection.Util;
+using Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget;
+using Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors;
+using Blackduck.Detect.Nuget.Inspector.Inspection.Util;
 
-namespace Synopsys.Detect.Nuget.Inspector.Inspection
+namespace Blackduck.Detect.Nuget.Inspector.Inspection
 {
     //Given a generic InspectionOptions, InspectorDispatch is responsible for instantiating the correct Inspector (Project or Solution)
     class InspectorDispatch

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectorExecutionResult.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectorExecutionResult.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.Result
+namespace Blackduck.Detect.Nuget.Inspector.Result
 {
     public class InspectorExecutionResult
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectorExecutor.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectorExecutor.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget;
-using Synopsys.Detect.Nuget.Inspector.Inspection.Util;
-using Synopsys.Detect.Nuget.Inspector.Result;
+using Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget;
+using Blackduck.Detect.Nuget.Inspector.Inspection.Util;
+using Blackduck.Detect.Nuget.Inspector.Result;
 
-namespace Synopsys.Detect.Nuget.Inspector.Inspection
+namespace Blackduck.Detect.Nuget.Inspector.Inspection
 {
     public class InspectorExecutor
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
@@ -9,13 +9,13 @@ using System.IO;
 using System.Text;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
-using Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget;
-using Synopsys.Detect.Nuget.Inspector.Inspection.Util;
-using Synopsys.Detect.Nuget.Inspector.Model;
-using Synopsys.Detect.Nuget.Inspector.DependencyResolution.PackagesConfig;
-using Synopsys.Detect.Nuget.Inspector.DependencyResolution.Project;
+using Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget;
+using Blackduck.Detect.Nuget.Inspector.Inspection.Util;
+using Blackduck.Detect.Nuget.Inspector.Model;
+using Blackduck.Detect.Nuget.Inspector.DependencyResolution.PackagesConfig;
+using Blackduck.Detect.Nuget.Inspector.DependencyResolution.Project;
 
-namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
+namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
 {
     class ProjectInspector : IInspector
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspectorOptions.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspectorOptions.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
+namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
 {
     class ProjectInspectionOptions : InspectionOptions
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
@@ -6,11 +6,11 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Build.Graph;
 using NuGet.Packaging;
-using Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget;
-using Synopsys.Detect.Nuget.Inspector.Inspection.Util;
-using Synopsys.Detect.Nuget.Inspector.Model;
+using Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget;
+using Blackduck.Detect.Nuget.Inspector.Inspection.Util;
+using Blackduck.Detect.Nuget.Inspector.Model;
 
-namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
+namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
 {
     class SolutionInspector : IInspector
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspectorOptions.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspectorOptions.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
+namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
 {
     class SolutionInspectionOptions : InspectionOptions
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Model/Container.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Model/Container.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.Model
+namespace Blackduck.Detect.Nuget.Inspector.Model
 {
     public class Container
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Model/InspectionOutput.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Model/InspectionOutput.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.Model
+namespace Blackduck.Detect.Nuget.Inspector.Model
 {
     public class InspectionOutput
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Model/PackageId.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Model/PackageId.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.Model
+namespace Blackduck.Detect.Nuget.Inspector.Model
 {
     public class PackageId
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Model/PackageSet.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Model/PackageSet.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.Model
+namespace Blackduck.Detect.Nuget.Inspector.Model
 {
     public class PackageSet
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Model/PackageSetBuilder.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Model/PackageSetBuilder.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.Model
+namespace Blackduck.Detect.Nuget.Inspector.Model
 {
     public class PackageSetBuilder
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/AssemblyInfoVersionParser.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/AssemblyInfoVersionParser.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.Inspection.Util
+namespace Blackduck.Detect.Nuget.Inspector.Inspection.Util
 {
     class AssemblyInfoVersionParser
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/ExcludedDependencyTypeUtil.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/ExcludedDependencyTypeUtil.cs
@@ -1,4 +1,4 @@
-namespace Synopsys.Detect.Nuget.Inspector.Inspection.Util
+namespace Blackduck.Detect.Nuget.Inspector.Inspection.Util
 {
 
     static class ExcludedDependencyTypeUtil

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/InspectionResultJsonWriter.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/InspectionResultJsonWriter.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Synopsys.Detect.Nuget.Inspector.Model;
+using Blackduck.Detect.Nuget.Inspector.Model;
 using Newtonsoft.Json;
 
-namespace Synopsys.Detect.Nuget.Inspector.Inspection.Util
+namespace Blackduck.Detect.Nuget.Inspector.Inspection.Util
 {
     class InspectionResultJsonWriter
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/InspectorUtil.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/InspectorUtil.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using static Synopsys.Detect.Nuget.Inspector.Inspection.Util.AssemblyInfoVersionParser;
+using static Blackduck.Detect.Nuget.Inspector.Inspection.Util.AssemblyInfoVersionParser;
 using System.Xml;
 
-namespace Synopsys.Detect.Nuget.Inspector.Inspection.Util
+namespace Blackduck.Detect.Nuget.Inspector.Inspection.Util
 {
     class InspectorUtil
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/PackageReferenceLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/PackageReferenceLoader.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Synopsys.Detect.Nuget.Inspector.Model;
+using Blackduck.Detect.Nuget.Inspector.Model;
 
-namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
+namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
 {
     interface PackageReferenceLoader
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/PathUtil.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/PathUtil.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.Inspection.Util
+namespace Blackduck.Detect.Nuget.Inspector.Inspection.Util
 {
     static class PathUtil
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/ProjectFile.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/ProjectFile.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
+namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
 {
     public class ProjectFile
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/ProjectNugetgPropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/ProjectNugetgPropertyLoader.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Xml;
-using Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget;
+using Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget;
 
-namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
+namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
 {
     class ProjectNugetgPropertyLoader : PropertyLoader
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/PropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/PropertyLoader.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
+namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
 {
     interface PropertyLoader
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryBuildPropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryBuildPropertyLoader.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Xml;
-using Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget;
-using Synopsys.Detect.Nuget.Inspector.Inspection.Util;
-using Synopsys.Detect.Nuget.Inspector.Model;
+using Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget;
+using Blackduck.Detect.Nuget.Inspector.Inspection.Util;
+using Blackduck.Detect.Nuget.Inspector.Model;
 
-namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
+namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
 {
     class SolutionDirectoryBuildPropertyLoader : PackageReferenceLoader
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryPackagesPropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SolutionDirectoryPackagesPropertyLoader.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Xml;
-using Synopsys.Detect.Nuget.Inspector.DependencyResolution.Nuget;
-using Synopsys.Detect.Nuget.Inspector.Inspection.Util;
-using Synopsys.Detect.Nuget.Inspector.Model;
+using Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget;
+using Blackduck.Detect.Nuget.Inspector.Inspection.Util;
+using Blackduck.Detect.Nuget.Inspector.Model;
 
-namespace Synopsys.Detect.Nuget.Inspector.Inspection.Inspectors
+namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
 {
     public class SolutionDirectoryPackagesPropertyLoader : PackageReferenceLoader
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SupportedProjectPatterns.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/SupportedProjectPatterns.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Synopsys.Detect.Nuget.Inspector.Inspection.Util
+namespace Blackduck.Detect.Nuget.Inspector.Inspection.Util
 {
     public static class SupportedProjectPatterns
     {

--- a/detect-nuget-inspector/detect-nuget-inspector/Program.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Program.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Build.Locator;
-using Synopsys.Detect.Nuget.Inspector.Configuration;
-using Synopsys.Detect.Nuget.Inspector.Inspection;
+using Blackduck.Detect.Nuget.Inspector.Configuration;
+using Blackduck.Detect.Nuget.Inspector.Inspection;
 
 class Program
 {

--- a/detect-nuget-inspector/detect-nuget-inspector/detect-nuget-inspector.csproj
+++ b/detect-nuget-inspector/detect-nuget-inspector/detect-nuget-inspector.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <RootNamespace>Synopsys.Detect.Nuget.Inspector</RootNamespace>
+    <RootNamespace>Blackduck.Detect.Nuget.Inspector</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>


### PR DESCRIPTION
Update Synopsys references to Blackduck.
The primary goal of this PR is to update group names for the  dependencies to use blackduck and to update package names to remove Synopsys from the namespace of code.