### PR TITLE
Add Support for Artifacts Path and Base Intermediate Output Path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 ext.dotNetExec = project.hasProperty('dotNetExec') ? project.getProperty('dotNetExec') : 'dotnet6'
 
 group 'com.blackduck.integration'
-version = '2.1.0-SIGQA1'
+version = '2.1.0-SIGQA2-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'distribution'

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 ext.dotNetExec = project.hasProperty('dotNetExec') ? project.getProperty('dotNetExec') : 'dotnet6'
 
 group 'com.blackduck.integration'
-version = '2.0.0-SNAPSHOT'
+version = '2.1.0-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'distribution'

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 ext.dotNetExec = project.hasProperty('dotNetExec') ? project.getProperty('dotNetExec') : 'dotnet6'
 
 group 'com.blackduck.integration'
-version = '2.1.0-SNAPSHOT'
+version = '2.1.0-SIGQA1'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'distribution'

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/AppConfigKeys.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/AppConfigKeys.cs
@@ -16,6 +16,6 @@ namespace Blackduck.Detect.Nuget.Inspector.Configuration
         public const string IncludedModules = "included_modules";
         public const string IgnoreFailures = "ignore_failure";
         public const string ExcludedDependencyTypes = "excluded_dependency_types";
-        public const string ArtifactsPath = "artifacts_path";
+        public const string ArtifactsPath = "nuget_artifacts_path";
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/AppConfigKeys.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/AppConfigKeys.cs
@@ -16,5 +16,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Configuration
         public const string IncludedModules = "included_modules";
         public const string IgnoreFailures = "ignore_failure";
         public const string ExcludedDependencyTypes = "excluded_dependency_types";
+        public const string ArtifactsPath = "artifacts_path";
+        public const string BaseIntermediateOutputPath = "base_intermediate_output_path";
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/AppConfigKeys.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/AppConfigKeys.cs
@@ -17,6 +17,5 @@ namespace Blackduck.Detect.Nuget.Inspector.Configuration
         public const string IgnoreFailures = "ignore_failure";
         public const string ExcludedDependencyTypes = "excluded_dependency_types";
         public const string ArtifactsPath = "artifacts_path";
-        public const string BaseIntermediateOutputPath = "base_intermediate_output_path";
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineArgKeys.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineArgKeys.cs
@@ -17,5 +17,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Configuration
         public const string IncludedModules = AppConfigKeys.IncludedModules;
         public const string IgnoreFailures = AppConfigKeys.IgnoreFailures;
         public const string ExcludedDependencyTypes = AppConfigKeys.ExcludedDependencyTypes;
+        public const string ArtifactsPath = AppConfigKeys.ArtifactsPath;
+        public const string BaseIntermediateOutputPath = AppConfigKeys.BaseIntermediateOutputPath;
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineArgKeys.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineArgKeys.cs
@@ -18,6 +18,5 @@ namespace Blackduck.Detect.Nuget.Inspector.Configuration
         public const string IgnoreFailures = AppConfigKeys.IgnoreFailures;
         public const string ExcludedDependencyTypes = AppConfigKeys.ExcludedDependencyTypes;
         public const string ArtifactsPath = AppConfigKeys.ArtifactsPath;
-        public const string BaseIntermediateOutputPath = AppConfigKeys.BaseIntermediateOutputPath;
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineRunOptions.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineRunOptions.cs
@@ -47,11 +47,6 @@ namespace Blackduck.Detect.Nuget.Inspector.Configuration
         [CommandLineArg(CommandLineArgKeys.ArtifactsPath, "The output path to Nuget build artifacts to derive package information from.")]
         public string ArtifactsPath = "";
 
-        
-        [AppConfigArg(AppConfigKeys.BaseIntermediateOutputPath)]
-        [CommandLineArg(CommandLineArgKeys.BaseIntermediateOutputPath, "The output path to Nuget build artifacts specifically the obj directory containing nuget package sources.")]
-        public string BaseIntermediateOutputPath = "";
-
 
         public bool ShowHelp;
         public bool Verbose;
@@ -70,7 +65,6 @@ namespace Blackduck.Detect.Nuget.Inspector.Configuration
                 ? this.ExcludedDependencyTypes
                 : overide.ExcludedDependencyTypes;
             ArtifactsPath = String.IsNullOrEmpty(overide.ArtifactsPath) ? this.ArtifactsPath : overide.ArtifactsPath;
-            BaseIntermediateOutputPath = String.IsNullOrEmpty(overide.BaseIntermediateOutputPath) ? this.BaseIntermediateOutputPath : overide.BaseIntermediateOutputPath;
         }
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineRunOptions.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineRunOptions.cs
@@ -42,6 +42,16 @@ namespace Blackduck.Detect.Nuget.Inspector.Configuration
         [AppConfigArg(AppConfigKeys.ExcludedDependencyTypes)]
         [CommandLineArg(CommandLineArgKeys.ExcludedDependencyTypes, "The names of the dependency types to exclude from dependency node generation")]
         public string ExcludedDependencyTypes = "";
+        
+        [AppConfigArg(AppConfigKeys.ArtifactsPath)]
+        [CommandLineArg(CommandLineArgKeys.ArtifactsPath, "The output path to Nuget build artifacts to derive package information from.")]
+        public string ArtifactsPath = "";
+
+        
+        [AppConfigArg(AppConfigKeys.BaseIntermediateOutputPath)]
+        [CommandLineArg(CommandLineArgKeys.BaseIntermediateOutputPath, "The output path to Nuget build artifacts specifically the obj directory containing nuget package sources.")]
+        public string BaseIntermediateOutputPath = "";
+
 
         public bool ShowHelp;
         public bool Verbose;
@@ -59,6 +69,8 @@ namespace Blackduck.Detect.Nuget.Inspector.Configuration
             ExcludedDependencyTypes = String.IsNullOrEmpty(overide.ExcludedDependencyTypes)
                 ? this.ExcludedDependencyTypes
                 : overide.ExcludedDependencyTypes;
+            ArtifactsPath = String.IsNullOrEmpty(overide.ArtifactsPath) ? this.ArtifactsPath : overide.ArtifactsPath;
+            BaseIntermediateOutputPath = String.IsNullOrEmpty(overide.BaseIntermediateOutputPath) ? this.BaseIntermediateOutputPath : overide.BaseIntermediateOutputPath;
         }
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineRunOptionsParser.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineRunOptionsParser.cs
@@ -67,7 +67,6 @@ namespace Blackduck.Detect.Nuget.Inspector.Configuration
             Console.WriteLine("Property {0} = {1}", CommandLineArgKeys.NugetConfigPath, options.NugetConfigPath);
             Console.WriteLine("Property {0} = {1}", CommandLineArgKeys.ExcludedDependencyTypes, options.ExcludedDependencyTypes);
             Console.WriteLine("Property {0} = {1}", CommandLineArgKeys.ArtifactsPath, options.ArtifactsPath);
-            Console.WriteLine("Property {0} = {1}", CommandLineArgKeys.BaseIntermediateOutputPath, options.BaseIntermediateOutputPath);
         }
 
         public RunOptions LoadAppSettings(string path)

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineRunOptionsParser.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/CommandLineRunOptionsParser.cs
@@ -66,6 +66,8 @@ namespace Blackduck.Detect.Nuget.Inspector.Configuration
             Console.WriteLine("Property {0} = {1}", CommandLineArgKeys.PackagesRepoUrl, options.PackagesRepoUrl);
             Console.WriteLine("Property {0} = {1}", CommandLineArgKeys.NugetConfigPath, options.NugetConfigPath);
             Console.WriteLine("Property {0} = {1}", CommandLineArgKeys.ExcludedDependencyTypes, options.ExcludedDependencyTypes);
+            Console.WriteLine("Property {0} = {1}", CommandLineArgKeys.ArtifactsPath, options.ArtifactsPath);
+            Console.WriteLine("Property {0} = {1}", CommandLineArgKeys.BaseIntermediateOutputPath, options.BaseIntermediateOutputPath);
         }
 
         public RunOptions LoadAppSettings(string path)

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/OptionParser.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/OptionParser.cs
@@ -44,8 +44,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Configuration
                     TargetPath = parsedOptions.TargetPath,
                     Verbose = parsedOptions.Verbose,
                     ExcludedDependencyTypes = parsedOptions.ExcludedDependencyTypes,
-                    ArtifactsPath = parsedOptions.ArtifactsPath,
-                    BaseIntermediateOutputPath = parsedOptions.BaseIntermediateOutputPath
+                    ArtifactsPath = parsedOptions.ArtifactsPath
                 };
 
                 return ParsedOptions.Succeeded(options);

--- a/detect-nuget-inspector/detect-nuget-inspector/Configuration/OptionParser.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Configuration/OptionParser.cs
@@ -43,7 +43,9 @@ namespace Blackduck.Detect.Nuget.Inspector.Configuration
                     NugetConfigPath = parsedOptions.NugetConfigPath,
                     TargetPath = parsedOptions.TargetPath,
                     Verbose = parsedOptions.Verbose,
-                    ExcludedDependencyTypes = parsedOptions.ExcludedDependencyTypes
+                    ExcludedDependencyTypes = parsedOptions.ExcludedDependencyTypes,
+                    ArtifactsPath = parsedOptions.ArtifactsPath,
+                    BaseIntermediateOutputPath = parsedOptions.BaseIntermediateOutputPath
                 };
 
                 return ParsedOptions.Succeeded(options);

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectionOptions.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectionOptions.cs
@@ -18,6 +18,5 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection
         public bool IgnoreFailure { get; set; } = false;
         public string ExcludedDependencyTypes { get; set; } = "NONE";
         public string ArtifactsPath { get; set; } = "";
-        public string BaseIntermediateOutputPath { get; set; } = "";
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectionOptions.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectionOptions.cs
@@ -17,5 +17,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection
         public string IncludedModules { get; set; } = "";
         public bool IgnoreFailure { get; set; } = false;
         public string ExcludedDependencyTypes { get; set; } = "NONE";
+        public string ArtifactsPath { get; set; } = "";
+        public string BaseIntermediateOutputPath { get; set; } = "";
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
@@ -339,7 +339,11 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
         {
             if (!String.IsNullOrWhiteSpace(Options.ArtifactsPath))
             {
-                return FindProjectArtifactsFolder();
+                if (Directory.Exists(Options.ArtifactsPath))
+                {
+                    return FindProjectArtifactsFolder();
+                }
+                Console.WriteLine("The Artifacts Path is invalid or Detect does not have appropriate permissions. Please specify a valid path.");
             }
             return PathUtil.Combine(projectDirectory, "obj", "project.assets.json");
         }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspector.cs
@@ -384,7 +384,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
             }
             else if (!String.IsNullOrWhiteSpace(Options.BaseIntermediateOutputPath))
             {
-                return PathUtil.Combine(Options.BaseIntermediateOutputPath, "project.assets.json");
+                return PathUtil.Combine(Options.BaseIntermediateOutputPath, Options.ProjectName, "project.assets.json");
             }
             return PathUtil.Combine(projectDirectory, "obj", "project.assets.json");
         }
@@ -402,7 +402,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
             }
             else if (!String.IsNullOrWhiteSpace(Options.BaseIntermediateOutputPath))
             {
-                return PathUtil.Combine(Options.BaseIntermediateOutputPath, projectName + ".csproj.nuget.g.props");
+                return PathUtil.Combine(Options.BaseIntermediateOutputPath, projectName, projectName + ".csproj.nuget.g.props");
             }
             return PathUtil.Combine(projectDirectory, "obj", projectName + ".csproj.nuget.g.props");
         }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspectorOptions.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspectorOptions.cs
@@ -20,6 +20,8 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
             this.IncludedModules = old.IncludedModules;
             this.IgnoreFailure = old.IgnoreFailure;
             this.ExcludedDependencyTypes = old.ExcludedDependencyTypes;
+            this.ArtifactsPath = old.ArtifactsPath;
+            this.BaseIntermediateOutputPath = old.BaseIntermediateOutputPath;
         }
 
         public string ProjectName { get; set; }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspectorOptions.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/ProjectInspectorOptions.cs
@@ -21,7 +21,6 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
             this.IgnoreFailure = old.IgnoreFailure;
             this.ExcludedDependencyTypes = old.ExcludedDependencyTypes;
             this.ArtifactsPath = old.ArtifactsPath;
-            this.BaseIntermediateOutputPath = old.BaseIntermediateOutputPath;
         }
 
         public string ProjectName { get; set; }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspectorOptions.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspectorOptions.cs
@@ -21,7 +21,6 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
             this.IgnoreFailure = old.IgnoreFailure;
             this.ExcludedDependencyTypes = old.ExcludedDependencyTypes;
             this.ArtifactsPath = old.ArtifactsPath;
-            this.BaseIntermediateOutputPath = old.BaseIntermediateOutputPath;
         }
 
         public string SolutionName { get; set; }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspectorOptions.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspectorOptions.cs
@@ -20,6 +20,8 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
             this.IncludedModules = old.IncludedModules;
             this.IgnoreFailure = old.IgnoreFailure;
             this.ExcludedDependencyTypes = old.ExcludedDependencyTypes;
+            this.ArtifactsPath = old.ArtifactsPath;
+            this.BaseIntermediateOutputPath = old.BaseIntermediateOutputPath;
         }
 
         public string SolutionName { get; set; }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Model/Container.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Model/Container.cs
@@ -12,7 +12,6 @@ namespace Blackduck.Detect.Nuget.Inspector.Model
         public string Version { get; set; }
         public string Type { get; set; } = "Solution";
         public string SourcePath { get; set; }
-        public List<string> OutputPaths { get; set; } = new List<string>();
         public List<PackageSet> Packages { get; set; } = new List<PackageSet>();
         public List<PackageId> Dependencies { get; set; } = new List<PackageId>();
         public List<Container> Children { get; set; } = new List<Container>();

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/ProjectNugetgPropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/ProjectNugetgPropertyLoader.cs
@@ -25,6 +25,15 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
 
             XmlDocument doc = new XmlDocument();
             doc.Load(PropertyPath);
+            
+            Microsoft.Build.Evaluation.Project proj = new Microsoft.Build.Evaluation.Project(PropertyPath);
+            string projectAssestsJsonPath = proj.GetPropertyValue("ProjectAssetsFile");
+            
+            if (!String.IsNullOrWhiteSpace(projectAssestsJsonPath))
+            {    
+                Microsoft.Build.Evaluation.ProjectCollection.GlobalProjectCollection.UnloadProject(proj);    
+                return projectAssestsJsonPath;
+            }
 
             XmlNodeList projectAssetsFileNodes = doc.GetElementsByTagName("ProjectAssetsFile");
             if (projectAssetsFileNodes != null && projectAssetsFileNodes.Count > 0)


### PR DESCRIPTION
This PR handles the ask in IDETECT-2437 and IDETECT-4547 to add support for custom artifact paths in Nuget Inspector. Such as build/libs in Gradle, nuget stores all its artifacts \obj folder for the built project. This path can be customised by properties such as ArtifactsPath and BaseIntermediateOutputPath in Directory.Build.props file. Nuget Inspector was only checking the default directory for project.assets.json file and therefore was not able to find some of the dependencies.

This PR would look for project.assets.json file for the project being scanned in the path which user would provide via a Detect property. If we will not be able to find the file, then we will continue the flow as normal Detect would today. 