### PR TITLE
Catch Exception when dotnet is not found

### DIFF
--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/ProjectNugetgPropertyLoader.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/ProjectNugetgPropertyLoader.cs
@@ -25,14 +25,22 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
 
             XmlDocument doc = new XmlDocument();
             doc.Load(PropertyPath);
-            
-            Microsoft.Build.Evaluation.Project proj = new Microsoft.Build.Evaluation.Project(PropertyPath);
-            string projectAssestsJsonPath = proj.GetPropertyValue("ProjectAssetsFile");
-            
-            if (!String.IsNullOrWhiteSpace(projectAssestsJsonPath))
-            {    
-                Microsoft.Build.Evaluation.ProjectCollection.GlobalProjectCollection.UnloadProject(proj);    
-                return projectAssestsJsonPath;
+
+
+            try
+            {
+                Microsoft.Build.Evaluation.Project proj = new Microsoft.Build.Evaluation.Project(PropertyPath);
+                string projectAssestsJsonPath = proj.GetPropertyValue("ProjectAssetsFile");
+                
+                if (!String.IsNullOrWhiteSpace(projectAssestsJsonPath))
+                {    
+                    Microsoft.Build.Evaluation.ProjectCollection.GlobalProjectCollection.UnloadProject(proj);    
+                    return projectAssestsJsonPath;
+                }
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("There was an error building the project using API, falling back to XML Parser");
             }
 
             XmlNodeList projectAssetsFileNodes = doc.GetElementsByTagName("ProjectAssetsFile");


### PR DESCRIPTION
Added a catch block when dotnet 6 is not found on the user machine for running Microsoft API, if dotnet is not found, we resolve to the back up XML Parser for getting the location of project.assets.json