### PR TITLE
Add support for dependency exclusions in json file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 ext.dotNetExec = project.hasProperty('dotNetExec') ? project.getProperty('dotNetExec') : 'dotnet6'
 
 group 'com.blackduck.integration'
-version = '2.1.1-SNAPSHOT'
+version = '2.2.0-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'distribution'

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/DependencyResult.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/DependencyResult.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Blackduck.Detect.Nuget.Inspector.Model;
 
 namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution
 {
@@ -10,7 +11,7 @@ namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution
     {
         public bool Success { get; set; } = true;
         public string ProjectVersion { get; set; } = null;
-        public List<Model.PackageSet> Packages { get; set; } = new List<Model.PackageSet>();
-        public List<Model.PackageId> Dependencies { get; set; } = new List<Model.PackageId>();
+        public HashSet<PackageSet> Packages { get; set; } = new HashSet<PackageSet>();
+        public HashSet<PackageId> Dependencies { get; set; } = new HashSet<PackageId>();
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/Resolver/NugetFlatResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/Resolver/NugetFlatResolver.cs
@@ -48,7 +48,7 @@ namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget
             return result;
         }
 
-        public List<Model.PackageSet> ProcessAll(List<NugetDependency> packages)
+        public HashSet<Model.PackageSet> ProcessAll(List<NugetDependency> packages)
         {
             foreach (NugetDependency package in packages)
             {

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/Resolver/NugetLockFileResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/Resolver/NugetLockFileResolver.cs
@@ -114,16 +114,11 @@ namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget
                 }
 
             }
-
-
-
-            if (LockFile.PackageSpec.Dependencies.Count != 0)
+           
+            foreach (var dep in LockFile.PackageSpec.Dependencies)
             {
-                foreach (var dep in LockFile.PackageSpec.Dependencies)
-                {
-                    var version = builder.GetBestVersion(dep.Name, dep.LibraryRange.VersionRange);
-                    result.Dependencies.Add(new Model.PackageId(dep.Name, version));
-                }
+                var version = builder.GetBestVersion(dep.Name, dep.LibraryRange.VersionRange);
+                result.Dependencies.Add(new Model.PackageId(dep.Name, version));
             }
 
             foreach (var projectFileDependencyGroup in LockFile.ProjectFileDependencyGroups)
@@ -141,28 +136,27 @@ namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget
                 }
             }
             
-            if(LockFile.PackageSpec.TargetFrameworks.Count != 0)
+            
+            foreach (var framework in LockFile.PackageSpec.TargetFrameworks)
             {
-                foreach (var framework in LockFile.PackageSpec.TargetFrameworks)
+                foreach (var dep in framework.Dependencies)
                 {
-                    foreach (var dep in framework.Dependencies)
-                    {
-                        bool isDevDependencyTypeExcluded = ExcludedDependencyTypeUtil.isDependencyTypeExcluded(ExcludedDependencyTypes,"DEV");
-                        bool excludeDevDependency = isDevDependencyTypeExcluded && (dep.SuppressParent == LibraryIncludeFlags.All);
+                    bool isDevDependencyTypeExcluded = ExcludedDependencyTypeUtil.isDependencyTypeExcluded(ExcludedDependencyTypes,"DEV");
+                    bool excludeDevDependency = isDevDependencyTypeExcluded && (dep.SuppressParent == LibraryIncludeFlags.All);
 
-                        if (!excludeDevDependency)
-                        {
-                            var version = builder.GetBestVersion(dep.Name, dep.LibraryRange.VersionRange);
-                            result.Dependencies.Add(new PackageId(dep.Name, version));
-                        }
-                        else
-                        {
-                            ExcludedDependencies.Add(dep.Name);
-                            result.Dependencies.RemoveWhere(package => package.Name.Equals(dep.Name));
-                        }
+                    if (!excludeDevDependency)
+                    {
+                        var version = builder.GetBestVersion(dep.Name, dep.LibraryRange.VersionRange);
+                        result.Dependencies.Add(new PackageId(dep.Name, version));
+                    }
+                    else
+                    {
+                        ExcludedDependencies.Add(dep.Name);
+                        result.Dependencies.RemoveWhere(package => package.Name.Equals(dep.Name));
                     }
                 }
             }
+            
 
 
             if (result.Dependencies.Count == 0)

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/Resolver/NugetLockFileResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/Resolver/NugetLockFileResolver.cs
@@ -3,16 +3,22 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Blackduck.Detect.Nuget.Inspector.Inspection.Util;
+using Blackduck.Detect.Nuget.Inspector.Model;
+using NuGet.LibraryModel;
 
 namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget
 {
     public class NugetLockFileResolver
     {
         private NuGet.ProjectModel.LockFile LockFile;
+        private string ExcludedDependencyTypes;
+        private HashSet<string> ExcludedDependencies = new HashSet<string>();
 
-        public NugetLockFileResolver(NuGet.ProjectModel.LockFile lockFile)
+        public NugetLockFileResolver(NuGet.ProjectModel.LockFile lockFile, string excludedDependencyTypes)
         {
             LockFile = lockFile;
+            ExcludedDependencyTypes = excludedDependencyTypes;
         }
 
         private NuGet.Versioning.NuGetVersion BestVersion(string name, NuGet.Versioning.VersionRange range, IList<NuGet.ProjectModel.LockFileTargetLibrary> libraries)
@@ -119,17 +125,6 @@ namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget
                     result.Dependencies.Add(new Model.PackageId(dep.Name, version));
                 }
             }
-            else
-            {
-                foreach (var framework in LockFile.PackageSpec.TargetFrameworks)
-                {
-                    foreach (var dep in framework.Dependencies)
-                    {
-                        var version = builder.GetBestVersion(dep.Name, dep.LibraryRange.VersionRange);
-                        result.Dependencies.Add(new Model.PackageId(dep.Name, version));
-                    }
-                }
-            }
 
             foreach (var projectFileDependencyGroup in LockFile.ProjectFileDependencyGroups)
             {
@@ -145,6 +140,29 @@ namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget
                     result.Dependencies.Add(new Model.PackageId(projectDependencyParsed.GetName(), version));
                 }
             }
+            
+            if(LockFile.PackageSpec.TargetFrameworks.Count != 0)
+            {
+                foreach (var framework in LockFile.PackageSpec.TargetFrameworks)
+                {
+                    foreach (var dep in framework.Dependencies)
+                    {
+                        bool isDevDependencyTypeExcluded = ExcludedDependencyTypeUtil.isDependencyTypeExcluded(ExcludedDependencyTypes,"DEV");
+                        bool excludeDevDependency = isDevDependencyTypeExcluded && (dep.SuppressParent == LibraryIncludeFlags.All);
+
+                        if (!excludeDevDependency)
+                        {
+                            var version = builder.GetBestVersion(dep.Name, dep.LibraryRange.VersionRange);
+                            result.Dependencies.Add(new PackageId(dep.Name, version));
+                        }
+                        else
+                        {
+                            ExcludedDependencies.Add(dep.Name);
+                            result.Dependencies.RemoveWhere(package => package.Name.Equals(dep.Name));
+                        }
+                    }
+                }
+            }
 
 
             if (result.Dependencies.Count == 0)
@@ -153,9 +171,17 @@ namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget
             }
 
             result.Packages = builder.GetPackageList();
+            ExcludeDevDependenciesFromPackages(result);
             return result;
         }
 
+        private void ExcludeDevDependenciesFromPackages(DependencyResult result)
+        {
+            if (ExcludedDependencies.Count != 0)
+            {
+                result.Packages.RemoveWhere(package => ExcludedDependencies.Contains(package.PackageId.Name));
+            }
+        }
 
 
         public ProjectFileDependency ParseProjectFileDependencyGroup(String projectFileDependency)

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/Resolver/NugetTreeResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Nuget/Resolver/NugetTreeResolver.cs
@@ -18,7 +18,7 @@ namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget
             nuget = service;
         }
 
-        public List<Model.PackageSet> GetPackageList()
+        public HashSet<Model.PackageSet> GetPackageList()
         {
             return builder.GetPackageList();
         }

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/PackagesConfig/PackagesConfigResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/PackagesConfig/PackagesConfigResolver.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using NuGet.Packaging;
 using Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget;
 using Blackduck.Detect.Nuget.Inspector.Inspection.Util;
+using Blackduck.Detect.Nuget.Inspector.Model;
 
 namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.PackagesConfig
 {
@@ -30,7 +31,7 @@ namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.PackagesConfig
             var result = new DependencyResult();
             result.Packages = CreatePackageSets(dependencies);
 
-            result.Dependencies = new List<Model.PackageId>();
+            result.Dependencies = new HashSet<PackageId>();
             foreach (var package in result.Packages)
             {
                 var anyPackageReferences = result.Packages.Where(pkg => pkg.Dependencies.Contains(package.PackageId)).Any();
@@ -72,7 +73,7 @@ namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.PackagesConfig
             return dependencies;
         }
 
-        private List<Model.PackageSet> CreatePackageSets(List<NugetDependency> dependencies)
+        private HashSet<Model.PackageSet> CreatePackageSets(List<NugetDependency> dependencies)
         {
             try
             {
@@ -92,7 +93,7 @@ namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.PackagesConfig
                 catch (Exception treeException)
                 {
                     Console.WriteLine("There was an issue processing packages.config as a tree: " + treeException.Message);
-                    var packages = new List<Model.PackageSet>(dependencies.Select(dependency => dependency.ToEmptyPackageSet()));
+                    var packages = new HashSet<PackageSet>(dependencies.Select(dependency => dependency.ToEmptyPackageSet()));
                     return packages;
                 }
             }

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectAssetsJsonResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectAssetsJsonResolver.cs
@@ -10,10 +10,12 @@ namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Project
     class ProjectAssetsJsonResolver : DependencyResolver
     {
         private string ProjectAssetsJsonPath;
+        private string ExcludedDependencyTypes;
 
-        public ProjectAssetsJsonResolver(string projectAssetsJsonPath)
+        public ProjectAssetsJsonResolver(string projectAssetsJsonPath, string excludedDependencyTypes)
         {
             ProjectAssetsJsonPath = projectAssetsJsonPath;
+            ExcludedDependencyTypes = excludedDependencyTypes;
         }
 
         public DependencyResult Process()
@@ -21,7 +23,7 @@ namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Project
 
             NuGet.ProjectModel.LockFile lockFile = NuGet.ProjectModel.LockFileUtilities.GetLockFile(ProjectAssetsJsonPath, null);
 
-            var resolver = new NugetLockFileResolver(lockFile);
+            var resolver = new NugetLockFileResolver(lockFile, ExcludedDependencyTypes);
 
             return resolver.Process();
         }

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectLockJsonResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectLockJsonResolver.cs
@@ -10,10 +10,12 @@ namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Project
     class ProjectLockJsonResolver : DependencyResolver
     {
         private string ProjectLockJsonPath;
+        private string ExcludedDependencyTypes;
 
-        public ProjectLockJsonResolver(string projectLockJsonPath)
+        public ProjectLockJsonResolver(string projectLockJsonPath, string excludedDependencyTypes)
         {
             ProjectLockJsonPath = projectLockJsonPath;
+            ExcludedDependencyTypes = excludedDependencyTypes;
         }
 
         public DependencyResult Process()
@@ -21,7 +23,7 @@ namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Project
 
             NuGet.ProjectModel.LockFile lockFile = NuGet.ProjectModel.LockFileUtilities.GetLockFile(ProjectLockJsonPath, null);
 
-            var resolver = new NugetLockFileResolver(lockFile);
+            var resolver = new NugetLockFileResolver(lockFile, ExcludedDependencyTypes);
 
             return resolver.Process();
         }

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectReferenceResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectReferenceResolver.cs
@@ -129,7 +129,7 @@ namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Project
                 {
                     Success = true,
                     Packages = tree.GetPackageList(),
-                    Dependencies = new List<PackageId>()
+                    Dependencies = new HashSet<PackageId>()
                 };
 
                 foreach (var package in result.Packages)

--- a/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/DependencyResolution/Project/ProjectXmlResolver.cs
@@ -135,7 +135,7 @@ namespace Blackduck.Detect.Nuget.Inspector.DependencyResolution.Project
             }
 
             result.Packages = tree.GetPackageList();
-            result.Dependencies = new List<PackageId>();
+            result.Dependencies = new HashSet<PackageId>();
             foreach (var package in result.Packages)
             {
                 var anyPackageReferences = result.Packages.Where(pkg => pkg.Dependencies.Contains(package.PackageId)).Any();

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Model/Container.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Model/Container.cs
@@ -12,8 +12,8 @@ namespace Blackduck.Detect.Nuget.Inspector.Model
         public string Version { get; set; }
         public string Type { get; set; } = "Solution";
         public string SourcePath { get; set; }
-        public List<PackageSet> Packages { get; set; } = new List<PackageSet>();
-        public List<PackageId> Dependencies { get; set; } = new List<PackageId>();
+        public HashSet<PackageSet> Packages { get; set; } = new HashSet<PackageSet>();
+        public HashSet<PackageId> Dependencies { get; set; } = new HashSet<PackageId>();
         public List<Container> Children { get; set; } = new List<Container>();
         public HashSet<PackageId> PackagePropertyPackages { get; set; } = new HashSet<PackageId>();
     }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Model/PackageSetBuilder.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Model/PackageSetBuilder.cs
@@ -55,9 +55,9 @@ namespace Blackduck.Detect.Nuget.Inspector.Model
             set.Dependencies.UnionWith(dependencies);
         }
 
-        public List<PackageSet> GetPackageList()
+        public HashSet<PackageSet> GetPackageList()
         {
-            return packageSets.Values.ToList();
+            return packageSets.Values.ToHashSet();
         }
 
         private class VersionPair


### PR DESCRIPTION
This PR fixes the issue in ticket IDETECT-4606 where dependencies were not excluded as part of json files because json files does not have a field for indicating if the dependency is a DEV or not. To tackle this, we found on field which indirectly co-ordinates with DEV dependency. A field called `SuppressParent` is set to `All` when corresponding `PrivateAssets` value is set in csproj files which means that a dependency is a DEV dependency. When this is set, we exclude that dependency from BOM.

Also, made some changes to already existing DependencyResult Object to make use of HashSet instead of List to avoid adding duplicate dependencies in the result to make it more clear and readable as part of tech debt.