### PR TITLE
Add support for .slnx files

### DIFF
--- a/detect-nuget-inspector/detect-nuget-inspector-tests/Files/Simple.sln
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/Files/Simple.sln
@@ -1,0 +1,33 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "my-app", "my-app\my-app.csproj", "{845B7716-6F03-4D02-8E86-79F95485B5D7}"
+EndProject
+Global
+        GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                Debug|Any CPU = Debug|Any CPU
+                Debug|x64 = Debug|x64
+                Debug|x86 = Debug|x86
+                Release|Any CPU = Release|Any CPU
+                Release|x64 = Release|x64
+                Release|x86 = Release|x86
+        EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {845B7716-6F03-4D02-8E86-79F95485B5D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {845B7716-6F03-4D02-8E86-79F95485B5D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {845B7716-6F03-4D02-8E86-79F95485B5D7}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {845B7716-6F03-4D02-8E86-79F95485B5D7}.Debug|x64.Build.0 = Debug|Any CPU
+                {845B7716-6F03-4D02-8E86-79F95485B5D7}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {845B7716-6F03-4D02-8E86-79F95485B5D7}.Debug|x86.Build.0 = Debug|Any CPU
+                {845B7716-6F03-4D02-8E86-79F95485B5D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {845B7716-6F03-4D02-8E86-79F95485B5D7}.Release|Any CPU.Build.0 = Release|Any CPU
+                {845B7716-6F03-4D02-8E86-79F95485B5D7}.Release|x64.ActiveCfg = Release|Any CPU
+                {845B7716-6F03-4D02-8E86-79F95485B5D7}.Release|x64.Build.0 = Release|Any CPU
+                {845B7716-6F03-4D02-8E86-79F95485B5D7}.Release|x86.ActiveCfg = Release|Any CPU
+                {845B7716-6F03-4D02-8E86-79F95485B5D7}.Release|x86.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
+                HideSolutionNode = FALSE
+        EndGlobalSection
+EndGlobal

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/Files/Simple.slnx
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/Files/Simple.slnx
@@ -1,0 +1,8 @@
+<Solution>
+  <Configurations>
+    <Platform Name="Any CPU" />
+    <Platform Name="x64" />
+    <Platform Name="x86" />
+  </Configurations>
+  <Project Path="my-app/my-app.csproj" />
+</Solution>

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/Inspection/Inspectors/SolutionInspectorTests.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/Inspection/Inspectors/SolutionInspectorTests.cs
@@ -33,8 +33,7 @@ namespace detect_nuget_inspector_tests.Inspection.Inspectors
         /// To test additional file pairs, add new [DataRow] entries with the .sln filename, .slnx filename, and solution name.
         /// </summary>
         [DataTestMethod]
-        [DataRow("PowerToys.sln", "PowerToys.slnx", "PowerToys")]
-        //[DataRow("Simple.sln", "Simple.slnx", "Simple")]  // Add your new pair here
+        [DataRow("Simple.sln", "Simple.slnx", "Simple")]  // Add your new pair here
         public void CompareSlnAndSlnxProjectLists(string slnFileName, string slnxFileName, string solutionName)
         {
             // Arrange

--- a/detect-nuget-inspector/detect-nuget-inspector-tests/Inspection/Inspectors/SolutionInspectorTests.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector-tests/Inspection/Inspectors/SolutionInspectorTests.cs
@@ -1,0 +1,70 @@
+using System.Reflection;
+using Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors;
+using Blackduck.Detect.Nuget.Inspector.Inspection.Util;
+using Blackduck.Detect.Nuget.Inspector.Model;
+
+namespace detect_nuget_inspector_tests.Inspection.Inspectors
+{
+    [TestClass]
+    public class SolutionInspectorTests
+    {
+        private string GetFilePath(string fileName)
+        {
+            string projectDirectory = Directory.GetParent(Environment.CurrentDirectory).Parent.Parent.FullName;
+            string filePath = Path.Combine(projectDirectory, "Files", fileName);
+            return filePath;
+        }
+
+        private List<ProjectFile> InvokePrivateMethod(SolutionInspector inspector, string methodName, string filePath)
+        {
+            var method = typeof(SolutionInspector).GetMethod(
+                methodName,
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                null,
+                new[] { typeof(string) },
+                null
+            );
+
+            return (List<ProjectFile>)method.Invoke(inspector, new object[] { filePath });
+        }
+
+        /// <summary>
+        /// Parametrized test that compares project lists from equivalent .sln and .slnx files.
+        /// To test additional file pairs, add new [DataRow] entries with the .sln filename, .slnx filename, and solution name.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("PowerToys.sln", "PowerToys.slnx", "PowerToys")]
+        //[DataRow("Simple.sln", "Simple.slnx", "Simple")]  // Add your new pair here
+        public void CompareSlnAndSlnxProjectLists(string slnFileName, string slnxFileName, string solutionName)
+        {
+            // Arrange
+            string slnFilePath = GetFilePath(slnFileName);
+            string slnxFilePath = GetFilePath(slnxFileName);
+
+            List<ProjectFile> slnProjects = SolutionInspector.FindProjectFilesFromSlnFile(slnFilePath);
+            // .slnx files list projects with forward slashes, so we need to sanitize .sln project paths for a fair comparison
+            slnProjects = slnProjects.Select(p => new ProjectFile { Name = p.Name, Path = PathUtil.Sanitize(p.Path) }).ToList();
+            List<ProjectFile> slnxProjects = SolutionInspector.FindProjectFilesFromSlnxFile(slnxFilePath);
+
+            // Assert
+            Assert.IsNotNull(slnProjects, "SLN projects list should not be null");
+            Assert.IsNotNull(slnxProjects, "SLNX projects list should not be null");
+            Assert.AreEqual(slnProjects.Count, slnxProjects.Count,
+                $"Project count mismatch for {solutionName}: SLN has {slnProjects.Count} projects, SLNX has {slnxProjects.Count} projects");
+
+            // Verify projects match by name and path (order does not matter)
+            var slnProjectsByName = slnProjects.OrderBy(p => p.Name).ToList();
+            var slnxProjectsByName = slnxProjects.OrderBy(p => p.Name).ToList();
+
+            for (int i = 0; i < slnProjectsByName.Count; i++)
+            {
+                Assert.AreEqual(slnProjectsByName[i].Name, slnxProjectsByName[i].Name,
+                    $"Project name mismatch at index {i} for {solutionName}");
+                Assert.AreEqual(slnProjectsByName[i].Path, slnxProjectsByName[i].Path,
+                    $"Project path mismatch for project '{slnProjectsByName[i].Name}' in {solutionName}");
+            }
+        }
+
+
+    }
+}

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectorDispatch.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectorDispatch.cs
@@ -31,7 +31,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection
         }
 
         // Warns and gives precedence to .sln over .slnx when both exist with the same base name
-        private static string[] FilterOutDuplicateXMLSolutionFiles(string[] solutionPaths)
+        private static string[] FilterOutDuplicateXMLSolutionFiles(string[] solutionPaths) // TODO refactor to single pass 
         {
             // Only bother if at least one .slnx file is present
             if (!solutionPaths.Any(f => f.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase)))
@@ -70,7 +70,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection
                     {
                         Console.WriteLine("Found Solution {0}", solution);
                         var solutionOp = new SolutionInspectionOptions(options);
-                        solutionOp.TargetPath = solution; // path to solution file
+                        solutionOp.TargetPath = solution;
                         inspectors.Add(new SolutionInspector(solutionOp, nugetService));
                     }
 

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectorDispatch.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectorDispatch.cs
@@ -22,7 +22,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection
             return CreateInspectors(options, nugetService)?.Select(insp => insp.Inspect()).ToList();
         }
 
-        private static string[] FindSolutionFiles(string directoryPath)
+        private static string[] FindSolutionFilesTopLevel(string directoryPath)
         {
             if (!Directory.Exists(directoryPath)) return Array.Empty<string>();
             return Directory.EnumerateFiles(directoryPath)
@@ -36,7 +36,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection
             if (Directory.Exists(options.TargetPath))
             {
                 Console.WriteLine("Searching for solution files to process...");
-                string[] solutionPaths = FindSolutionFiles(options.TargetPath); 
+                string[] solutionPaths = FindSolutionFilesTopLevel(options.TargetPath); 
 
                 if (solutionPaths != null && solutionPaths.Length >= 1)
                 {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectorDispatch.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectorDispatch.cs
@@ -58,7 +58,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection
         public List<IInspector> CreateInspectors(InspectionOptions options, NugetSearchService nugetService)
         {
             var inspectors = new List<IInspector>();
-            if (Directory.Exists(options.TargetPath))
+            if (Directory.Exists(options.TargetPath)) // src dir
             {
                 Console.WriteLine("Searching for solution files to process...");
                 string[] solutionPaths = FindSolutionFilesTopLevel(options.TargetPath);
@@ -70,7 +70,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection
                     {
                         Console.WriteLine("Found Solution {0}", solution);
                         var solutionOp = new SolutionInspectionOptions(options);
-                        solutionOp.TargetPath = solution;
+                        solutionOp.TargetPath = solution; // path to solution file
                         inspectors.Add(new SolutionInspector(solutionOp, nugetService));
                     }
 
@@ -97,7 +97,12 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection
             }
             else if (File.Exists(options.TargetPath))
             {
-                if (options.TargetPath.Contains(".sln"))
+                var fileExtension = Path.GetExtension(options.TargetPath);
+                if (string.IsNullOrEmpty(fileExtension))
+                {
+                    Console.WriteLine($"TargetPath '{options.TargetPath}' does not have a file extension. Skipping.");
+                }
+                else if (fileExtension.Equals(".sln", StringComparison.OrdinalIgnoreCase) || fileExtension.Equals(".slnx", StringComparison.OrdinalIgnoreCase))
                 {
                     var solutionOp = new SolutionInspectionOptions(options);
                     solutionOp.TargetPath = options.TargetPath;

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectorDispatch.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectorDispatch.cs
@@ -22,13 +22,21 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection
             return CreateInspectors(options, nugetService)?.Select(insp => insp.Inspect()).ToList();
         }
 
+        private static string[] FindSolutionFiles(string directoryPath)
+        {
+            if (!Directory.Exists(directoryPath)) return Array.Empty<string>();
+            return Directory.EnumerateFiles(directoryPath)
+                .Where(f => f.EndsWith(".sln", StringComparison.OrdinalIgnoreCase) || f.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+        }
+
         public List<IInspector> CreateInspectors(InspectionOptions options, NugetSearchService nugetService)
         {
             var inspectors = new List<IInspector>();
             if (Directory.Exists(options.TargetPath))
             {
                 Console.WriteLine("Searching for solution files to process...");
-                string[] solutionPaths = Directory.GetFiles(options.TargetPath, "*.sln");
+                string[] solutionPaths = FindSolutionFiles(options.TargetPath); 
 
                 if (solutionPaths != null && solutionPaths.Length >= 1)
                 {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectorDispatch.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectorDispatch.cs
@@ -58,7 +58,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection
         public List<IInspector> CreateInspectors(InspectionOptions options, NugetSearchService nugetService)
         {
             var inspectors = new List<IInspector>();
-            if (Directory.Exists(options.TargetPath)) // src dir
+            if (Directory.Exists(options.TargetPath))
             {
                 Console.WriteLine("Searching for solution files to process...");
                 string[] solutionPaths = FindSolutionFilesTopLevel(options.TargetPath);

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectorDispatch.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/InspectorDispatch.cs
@@ -30,13 +30,39 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection
                 .ToArray();
         }
 
+        // Warns and gives precedence to .sln over .slnx when both exist with the same base name
+        private static string[] FilterOutDuplicateXMLSolutionFiles(string[] solutionPaths)
+        {
+            // Only bother if at least one .slnx file is present
+            if (!solutionPaths.Any(f => f.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase)))
+            {
+                return solutionPaths;
+            }
+            var slnFiles = solutionPaths.Where(f => f.EndsWith(".sln", StringComparison.OrdinalIgnoreCase)).ToList();
+            var slnxFiles = solutionPaths.Where(f => f.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase)).ToList();
+            var slnBaseNames = new HashSet<string>(slnFiles.Select(f => Path.GetFileNameWithoutExtension(f)), StringComparer.OrdinalIgnoreCase);
+            var slnxBaseNames = new HashSet<string>(slnxFiles.Select(f => Path.GetFileNameWithoutExtension(f)), StringComparer.OrdinalIgnoreCase);
+            var duplicateBaseNames = slnBaseNames.Intersect(slnxBaseNames, StringComparer.OrdinalIgnoreCase).ToList();
+            if (duplicateBaseNames.Count > 0)
+            {
+                foreach (var baseName in duplicateBaseNames)
+                {
+                    Console.WriteLine($"Warning: Both {baseName}.sln and {baseName}.slnx found. Only {baseName}.sln will be processed, {baseName}.slnx will be ignored.");
+                }
+                // Remove .slnx files with the same base name as a .sln file
+                solutionPaths = solutionPaths.Where(f => !(f.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase) && duplicateBaseNames.Contains(Path.GetFileNameWithoutExtension(f), StringComparer.OrdinalIgnoreCase))).ToArray();
+            }
+            return solutionPaths;
+        }
+
         public List<IInspector> CreateInspectors(InspectionOptions options, NugetSearchService nugetService)
         {
             var inspectors = new List<IInspector>();
             if (Directory.Exists(options.TargetPath))
             {
                 Console.WriteLine("Searching for solution files to process...");
-                string[] solutionPaths = FindSolutionFilesTopLevel(options.TargetPath); 
+                string[] solutionPaths = FindSolutionFilesTopLevel(options.TargetPath);
+                solutionPaths = FilterOutDuplicateXMLSolutionFiles(solutionPaths);
 
                 if (solutionPaths != null && solutionPaths.Length >= 1)
                 {

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
@@ -85,7 +85,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
                     solution.InspectedFiles.Add(solutionDirectoryPackagesPropertyPath);
                 }
 
-                // PROCESS SOLUTION LEVEL Directory.Build.props TODO: refactor
+                // PROCESS SOLUTION LEVEL Directory.Build.props
                 HashSet<PackageId> buildPropertyPackages = new HashSet<PackageId>();
                 
                 string solutionDirectoryBuildPropertyPath = CreateSolutionDirectoryBuildPropertyPath(parentDirectory);

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Build.Graph;
+﻿using System.Diagnostics;
+using System.Xml.Linq;
 using NuGet.Packaging;
 using Blackduck.Detect.Nuget.Inspector.DependencyResolution.Nuget;
 using Blackduck.Detect.Nuget.Inspector.Inspection.Util;
@@ -75,6 +70,8 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
                 HashSet<PackageId> globalPackageReferences = new HashSet<PackageId>();
                 string parentDirectory = Directory.GetParent(solution.SourcePath).FullName;
                 
+                
+                // PROCESS SOLUTION LEVEL Directory.Packages.props TODO: refactor
                 string solutionDirectoryPackagesPropertyPath = CreateSolutionDirectoryPackagesPropertyPath(parentDirectory);
                 bool solutionDirectoryPackagesPropertyExists = !String.IsNullOrWhiteSpace(solutionDirectoryPackagesPropertyPath) && File.Exists(solutionDirectoryPackagesPropertyPath);
                 bool checkVersionOverride = true;
@@ -88,6 +85,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
                     solution.InspectedFiles.Add(solutionDirectoryPackagesPropertyPath);
                 }
 
+                // PROCESS SOLUTION LEVEL Directory.Build.props TODO: refactor
                 HashSet<PackageId> buildPropertyPackages = new HashSet<PackageId>();
                 
                 string solutionDirectoryBuildPropertyPath = CreateSolutionDirectoryBuildPropertyPath(parentDirectory);
@@ -100,7 +98,9 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
                     checkVersionOverride = propertyLoader.GetVersionOverrideEnabled();
                 }
                 
+                // GET PROJECTS FROM SLN FILE. 
                 List<ProjectFile> projectFiles = FindProjectFilesFromSolutionFile(Options.TargetPath);
+                // ///////TODO if .slnx, call new get projects from slnx file method. get some example projects to test with. including the weird scenario/bug
                 Console.WriteLine("Parsed Solution File");
                 if (projectFiles.Count > 0)
                 {
@@ -151,7 +151,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
                             string projectId = projectName;
                             if (duplicateNames.Contains(projectId))
                             {
-                                Console.WriteLine($"Duplicate project name '{projectId}' found. Using GUID instead.");
+                                Console.WriteLine($"Duplicate project name '{projectId}' found. Using GUID instead."); // not a thing in new XML file ... 
                                 projectId = project.GUID;
                             }
                             Boolean projectFileExists = false;
@@ -257,6 +257,22 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
 
         private List<ProjectFile> FindProjectFilesFromSolutionFile(string solutionPath)
         {
+            string extension = Path.GetExtension(solutionPath).ToLowerInvariant();
+            if (extension == ".sln")
+            {
+                return FindProjectFilesFromSlnFile(solutionPath);
+            }
+            if (extension == ".slnx")
+            {
+                return FindProjectFilesFromSlnxFile(solutionPath);
+            }
+            // return an empty list instead maybe?
+            throw new Exception($"Unsupported solution file extension: {extension}"); // would never happen because of the way inspectors are dispatched
+            
+        }
+
+        private List<ProjectFile> FindProjectFilesFromSlnFile(string solutionPath)
+        {
             var projects = new List<ProjectFile>();
             // Visual Studio right now is not resolving the Microsoft.Build.Construction.SolutionFile type
             // parsing the solution file manually for now.
@@ -291,6 +307,31 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
                 throw new System.Exception("Solution File " + solutionPath + " not found");
             }
 
+            return projects;
+        }
+        
+        private List<ProjectFile> FindProjectFilesFromSlnxFile(string solutionPath)
+        {
+            var projects = new List<ProjectFile>();
+            if (File.Exists(solutionPath))
+            {
+                var doc = XDocument.Load(solutionPath);
+                var projectElements = doc.Descendants("Project");
+                foreach (var element in projectElements)
+                {
+                    string name = element.Attribute("Name")?.Value;
+                    string path = element.Attribute("Path")?.Value;
+                    string guid = element.Attribute("Guid")?.Value;
+                    if (!string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(path))
+                    {
+                        projects.Add(new ProjectFile { Name = name, Path = path, GUID = guid });
+                    }
+                }
+            }
+            else
+            {
+                throw new Exception("Solution File " + solutionPath + " not found");
+            }
             return projects;
         }
 

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
@@ -124,7 +124,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
                                 bool fileNotFound = true;
                                 while (fileNotFound)
                                 {
-                                    string checkFile = Path.Combine(parentPath, projectRelativePath);
+                                    string checkFile = PathUtil.Combine(parentPath, projectRelativePath);
                                     if (parentPath.Equals("") || parentPath.Equals(Path.GetPathRoot(solutionDirectory)))
                                     {
                                         Console.WriteLine("The Path provided in the sln file is wrong, will skip parsing over this file");
@@ -249,7 +249,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
             return solution;
         }
 
-        private List<ProjectFile> FindProjectFilesFromSolutionFile(string solutionPath)
+        public static List<ProjectFile> FindProjectFilesFromSolutionFile(string solutionPath)
         {
             string extension = Path.GetExtension(solutionPath).ToLowerInvariant();
             if (extension == ".sln")
@@ -263,7 +263,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
             throw new Exception($"Unsupported solution file extension: {extension}");
         }
 
-        private List<ProjectFile> FindProjectFilesFromSlnFile(string solutionPath)
+        public static List<ProjectFile> FindProjectFilesFromSlnFile(string solutionPath)
         {
             var projects = new List<ProjectFile>();
             // Visual Studio right now is not resolving the Microsoft.Build.Construction.SolutionFile type
@@ -302,7 +302,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
             return projects;
         }
         
-        private List<ProjectFile> FindProjectFilesFromSlnxFile(string solutionPath)
+        public static List<ProjectFile> FindProjectFilesFromSlnxFile(string solutionPath)
         {
             // The line we care about looks like this: <Project Path="my-app/my-app.csproj" />
             var projects = new List<ProjectFile>();

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
@@ -58,7 +58,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
 
         public Container GetContainer()
         {
-            Console.WriteLine("Processing Solution: " + Options.TargetPath); // abs path to .sln file
+            Console.WriteLine("Processing Solution: " + Options.TargetPath);
             var stopwatch = Stopwatch.StartNew();
             Container solution = new Container();
             solution.Name = Options.SolutionName;
@@ -71,7 +71,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
                 string parentDirectory = Directory.GetParent(solution.SourcePath).FullName;
                 
                 
-                // PROCESS SOLUTION LEVEL Directory.Packages.props TODO: refactor
+                // PROCESS SOLUTION LEVEL Directory.Packages.props
                 string solutionDirectoryPackagesPropertyPath = CreateSolutionDirectoryPackagesPropertyPath(parentDirectory);
                 bool solutionDirectoryPackagesPropertyExists = !String.IsNullOrWhiteSpace(solutionDirectoryPackagesPropertyPath) && File.Exists(solutionDirectoryPackagesPropertyPath);
                 bool checkVersionOverride = true;
@@ -82,7 +82,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
                     packagesProperty = packagePropertyLoader.Process();
                     globalPackageReferences = packagePropertyLoader.GetGlobalPackageReferences();
                     checkVersionOverride = packagePropertyLoader.GetVersionOverrideEnabled();
-                    solution.InspectedFiles.Add(solutionDirectoryPackagesPropertyPath); // wait what did i add this for quack
+                    solution.InspectedFiles.Add(solutionDirectoryPackagesPropertyPath);
                 }
 
                 // PROCESS SOLUTION LEVEL Directory.Build.props TODO: refactor
@@ -100,7 +100,6 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
                 
                 // GET PROJECTS FROM SLN FILE. 
                 List<ProjectFile> projectFiles = FindProjectFilesFromSolutionFile(Options.TargetPath);
-                // ///////TODO if .slnx, call new get projects from slnx file method. get some example projects to test with. including the weird scenario/bug
                 Console.WriteLine("Parsed Solution File");
                 if (projectFiles.Count > 0)
                 {
@@ -146,7 +145,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
                             string projectId = projectName;
                             if (duplicateNames.Contains(projectId))
                             {
-                                Console.WriteLine($"Duplicate project name '{projectId}' found. Using GUID instead."); // not a thing in new XML file ... The .slnx format is designed to eliminate the "useless duplication" found in legacy .sln files. While the XML structure itself technically allows multiple <Project> elements with the same path, the underlying project model treats the Path as the unique identifier for a project within the solution.
+                                Console.WriteLine($"Duplicate project name '{projectId}' found. Using GUID instead.");
                                 projectId = project.GUID;
                             }
                             Boolean projectFileExists = false;
@@ -261,8 +260,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
             {
                 return FindProjectFilesFromSlnxFile(solutionPath);
             }
-            // return an empty list instead maybe?
-            throw new Exception($"Unsupported solution file extension: {extension}"); // would never happen because of the way inspectors are dispatched right?
+            throw new Exception($"Unsupported solution file extension: {extension}");
         }
 
         private List<ProjectFile> FindProjectFilesFromSlnFile(string solutionPath)

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
@@ -66,25 +66,19 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
             Console.WriteLine("Processing Solution: " + Options.TargetPath);
             var stopwatch = Stopwatch.StartNew();
             Container solution = new Container();
-            solution.Name = Options.SolutionName;
-            solution.SourcePath = Options.TargetPath;
+            solution.Name = Options.SolutionName; // without extension here
+            solution.SourcePath = Options.TargetPath; // full path to the solution file w/ extension
             solution.Type = "Solution";
             try
             {
-                HashSet<PackageId> packagesProperty = new HashSet<PackageId>();
-                HashSet<PackageId> globalPackageReferences = new HashSet<PackageId>();
+                HashSet<PackageId> packagesProperty;
+                HashSet<PackageId> globalPackageReferences;
+                bool checkVersionOverride;
                 string parentDirectory = Directory.GetParent(solution.SourcePath).FullName;
-                
-                string solutionDirectoryPackagesPropertyPath = CreateSolutionDirectoryPackagesPropertyPath(parentDirectory);
-                bool solutionDirectoryPackagesPropertyExists = !String.IsNullOrWhiteSpace(solutionDirectoryPackagesPropertyPath) && File.Exists(solutionDirectoryPackagesPropertyPath);
-                bool checkVersionOverride = true;
-                if (solutionDirectoryPackagesPropertyExists)
+                string excludedDependencyTypesString = string.Join(",", Options.ExcludedDependencyTypes);
+                string solutionDirectoryPackagesPropertyPath = GetSolutionLevelDirectoryPackagesProps(parentDirectory, excludedDependencyTypesString, out packagesProperty, out globalPackageReferences, out checkVersionOverride);
+                if (!string.IsNullOrWhiteSpace(solutionDirectoryPackagesPropertyPath))
                 {
-                    Console.WriteLine("Using solution directory packages property file: " + solutionDirectoryPackagesPropertyPath);
-                    var packagePropertyLoader = new SolutionDirectoryPackagesPropertyLoader(solutionDirectoryPackagesPropertyPath, Options.ExcludedDependencyTypes);
-                    packagesProperty = packagePropertyLoader.Process();
-                    globalPackageReferences = packagePropertyLoader.GetGlobalPackageReferences();
-                    checkVersionOverride = packagePropertyLoader.GetVersionOverrideEnabled();
                     solution.InspectedFiles.Add(solutionDirectoryPackagesPropertyPath);
                 }
 
@@ -302,6 +296,26 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
         private string CreateSolutionDirectoryPackagesPropertyPath(string solutionDirectory)
         {
             return PathUtil.Combine(solutionDirectory, "Directory.Packages.props");
+        }
+
+        // Helper method to encapsulate solution-level Directory.Packages.props logic
+        private string GetSolutionLevelDirectoryPackagesProps(string parentDirectory, string excludedDependencyTypes, out HashSet<PackageId> packagesProperty, out HashSet<PackageId> globalPackageReferences, out bool checkVersionOverride)
+        {
+            packagesProperty = new HashSet<PackageId>();
+            globalPackageReferences = new HashSet<PackageId>();
+            checkVersionOverride = true;
+            string solutionDirectoryPackagesPropertyPath = CreateSolutionDirectoryPackagesPropertyPath(parentDirectory);
+            bool solutionDirectoryPackagesPropertyExists = !String.IsNullOrWhiteSpace(solutionDirectoryPackagesPropertyPath) && File.Exists(solutionDirectoryPackagesPropertyPath);
+            if (solutionDirectoryPackagesPropertyExists)
+            {
+                Console.WriteLine("Using solution directory packages property file: " + solutionDirectoryPackagesPropertyPath);
+                var packagePropertyLoader = new SolutionDirectoryPackagesPropertyLoader(solutionDirectoryPackagesPropertyPath, excludedDependencyTypes);
+                packagesProperty = packagePropertyLoader.Process();
+                globalPackageReferences = packagePropertyLoader.GetGlobalPackageReferences();
+                checkVersionOverride = packagePropertyLoader.GetVersionOverrideEnabled();
+                return solutionDirectoryPackagesPropertyPath;
+            }
+            return null;
         }
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
@@ -58,7 +58,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
 
         public Container GetContainer()
         {
-            Console.WriteLine("Processing Solution: " + Options.TargetPath);
+            Console.WriteLine("Processing Solution: " + Options.TargetPath); // abs path to .sln file
             var stopwatch = Stopwatch.StartNew();
             Container solution = new Container();
             solution.Name = Options.SolutionName;
@@ -82,7 +82,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
                     packagesProperty = packagePropertyLoader.Process();
                     globalPackageReferences = packagePropertyLoader.GetGlobalPackageReferences();
                     checkVersionOverride = packagePropertyLoader.GetVersionOverrideEnabled();
-                    solution.InspectedFiles.Add(solutionDirectoryPackagesPropertyPath);
+                    solution.InspectedFiles.Add(solutionDirectoryPackagesPropertyPath); // wait what did i add this for quack
                 }
 
                 // PROCESS SOLUTION LEVEL Directory.Build.props TODO: refactor
@@ -109,11 +109,6 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
 
                     var duplicateNames = projectFiles
                         .GroupBy(project => project.Name)
-                        .Where(group => group.Count() > 1)
-                        .Select(group => group.Key);
-
-                    var duplicatePaths = projectFiles
-                        .GroupBy(project => project.Path)
                         .Where(group => group.Count() > 1)
                         .Select(group => group.Key);
 
@@ -151,7 +146,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
                             string projectId = projectName;
                             if (duplicateNames.Contains(projectId))
                             {
-                                Console.WriteLine($"Duplicate project name '{projectId}' found. Using GUID instead."); // not a thing in new XML file ... 
+                                Console.WriteLine($"Duplicate project name '{projectId}' found. Using GUID instead."); // not a thing in new XML file ... The .slnx format is designed to eliminate the "useless duplication" found in legacy .sln files. While the XML structure itself technically allows multiple <Project> elements with the same path, the underlying project model treats the Path as the unique identifier for a project within the solution.
                                 projectId = project.GUID;
                             }
                             Boolean projectFileExists = false;
@@ -267,8 +262,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
                 return FindProjectFilesFromSlnxFile(solutionPath);
             }
             // return an empty list instead maybe?
-            throw new Exception($"Unsupported solution file extension: {extension}"); // would never happen because of the way inspectors are dispatched
-            
+            throw new Exception($"Unsupported solution file extension: {extension}"); // would never happen because of the way inspectors are dispatched right?
         }
 
         private List<ProjectFile> FindProjectFilesFromSlnFile(string solutionPath)
@@ -312,26 +306,37 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
         
         private List<ProjectFile> FindProjectFilesFromSlnxFile(string solutionPath)
         {
+            // The line we care about looks like this: <Project Path="my-app/my-app.csproj" />
             var projects = new List<ProjectFile>();
-            if (File.Exists(solutionPath))
+            if (!File.Exists(solutionPath))
             {
-                var doc = XDocument.Load(solutionPath);
-                var projectElements = doc.Descendants("Project");
-                foreach (var element in projectElements)
+                throw new FileNotFoundException("Solution File " + solutionPath + " not found");
+            }
+            XDocument doc = XDocument.Load(solutionPath);
+            
+            var seenPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (XElement node in doc.Descendants("Project"))
+            {
+                string? projectRelativePath = node.Attribute("Path")?.Value;
+                if (string.IsNullOrEmpty(projectRelativePath))
                 {
-                    string name = element.Attribute("Name")?.Value;
-                    string path = element.Attribute("Path")?.Value;
-                    string guid = element.Attribute("Guid")?.Value;
-                    if (!string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(path))
-                    {
-                        projects.Add(new ProjectFile { Name = name, Path = path, GUID = guid });
-                    }
+                    continue;
                 }
+                
+                if (!seenPaths.Add(projectRelativePath))
+                {
+                    Console.WriteLine("Duplicate project path '{0}' found in .slnx file, skipping.", projectRelativePath);
+                    continue;
+                }
+                
+                string name = Path.GetFileNameWithoutExtension(projectRelativePath);
+
+                // slnx files do not have GUIDs, the relative path is the unique ID. 
+                projects.Add(new ProjectFile { Name = name, Path = projectRelativePath, GUID = string.Empty });
             }
-            else
-            {
-                throw new Exception("Solution File " + solutionPath + " not found");
-            }
+
+            Console.WriteLine("Nuget Inspector found {0} project elements in .slnx file", projects.Count);
             return projects;
         }
 

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Inspectors/SolutionInspector.cs
@@ -66,19 +66,25 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
             Console.WriteLine("Processing Solution: " + Options.TargetPath);
             var stopwatch = Stopwatch.StartNew();
             Container solution = new Container();
-            solution.Name = Options.SolutionName; // without extension here
-            solution.SourcePath = Options.TargetPath; // full path to the solution file w/ extension
+            solution.Name = Options.SolutionName;
+            solution.SourcePath = Options.TargetPath;
             solution.Type = "Solution";
             try
             {
-                HashSet<PackageId> packagesProperty;
-                HashSet<PackageId> globalPackageReferences;
-                bool checkVersionOverride;
+                HashSet<PackageId> packagesProperty = new HashSet<PackageId>();
+                HashSet<PackageId> globalPackageReferences = new HashSet<PackageId>();
                 string parentDirectory = Directory.GetParent(solution.SourcePath).FullName;
-                string excludedDependencyTypesString = string.Join(",", Options.ExcludedDependencyTypes);
-                string solutionDirectoryPackagesPropertyPath = GetSolutionLevelDirectoryPackagesProps(parentDirectory, excludedDependencyTypesString, out packagesProperty, out globalPackageReferences, out checkVersionOverride);
-                if (!string.IsNullOrWhiteSpace(solutionDirectoryPackagesPropertyPath))
+                
+                string solutionDirectoryPackagesPropertyPath = CreateSolutionDirectoryPackagesPropertyPath(parentDirectory);
+                bool solutionDirectoryPackagesPropertyExists = !String.IsNullOrWhiteSpace(solutionDirectoryPackagesPropertyPath) && File.Exists(solutionDirectoryPackagesPropertyPath);
+                bool checkVersionOverride = true;
+                if (solutionDirectoryPackagesPropertyExists)
                 {
+                    Console.WriteLine("Using solution directory packages property file: " + solutionDirectoryPackagesPropertyPath);
+                    var packagePropertyLoader = new SolutionDirectoryPackagesPropertyLoader(solutionDirectoryPackagesPropertyPath, Options.ExcludedDependencyTypes);
+                    packagesProperty = packagePropertyLoader.Process();
+                    globalPackageReferences = packagePropertyLoader.GetGlobalPackageReferences();
+                    checkVersionOverride = packagePropertyLoader.GetVersionOverrideEnabled();
                     solution.InspectedFiles.Add(solutionDirectoryPackagesPropertyPath);
                 }
 
@@ -296,26 +302,6 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Inspectors
         private string CreateSolutionDirectoryPackagesPropertyPath(string solutionDirectory)
         {
             return PathUtil.Combine(solutionDirectory, "Directory.Packages.props");
-        }
-
-        // Helper method to encapsulate solution-level Directory.Packages.props logic
-        private string GetSolutionLevelDirectoryPackagesProps(string parentDirectory, string excludedDependencyTypes, out HashSet<PackageId> packagesProperty, out HashSet<PackageId> globalPackageReferences, out bool checkVersionOverride)
-        {
-            packagesProperty = new HashSet<PackageId>();
-            globalPackageReferences = new HashSet<PackageId>();
-            checkVersionOverride = true;
-            string solutionDirectoryPackagesPropertyPath = CreateSolutionDirectoryPackagesPropertyPath(parentDirectory);
-            bool solutionDirectoryPackagesPropertyExists = !String.IsNullOrWhiteSpace(solutionDirectoryPackagesPropertyPath) && File.Exists(solutionDirectoryPackagesPropertyPath);
-            if (solutionDirectoryPackagesPropertyExists)
-            {
-                Console.WriteLine("Using solution directory packages property file: " + solutionDirectoryPackagesPropertyPath);
-                var packagePropertyLoader = new SolutionDirectoryPackagesPropertyLoader(solutionDirectoryPackagesPropertyPath, excludedDependencyTypes);
-                packagesProperty = packagePropertyLoader.Process();
-                globalPackageReferences = packagePropertyLoader.GetGlobalPackageReferences();
-                checkVersionOverride = packagePropertyLoader.GetVersionOverrideEnabled();
-                return solutionDirectoryPackagesPropertyPath;
-            }
-            return null;
         }
     }
 }

--- a/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/PathUtil.cs
+++ b/detect-nuget-inspector/detect-nuget-inspector/Inspection/Util/PathUtil.cs
@@ -16,7 +16,7 @@ namespace Blackduck.Detect.Nuget.Inspector.Inspection.Util
         public static string Combine(params string[] pathSegments)
         {
             String path = Path.Combine(pathSegments);
-            return path.Replace("\\", "/");
+            return Sanitize(path);
         }
 
         public static string Sanitize(String path)

--- a/detect-nuget-inspector/detect-nuget-inspector/detect-nuget-inspector.csproj
+++ b/detect-nuget-inspector/detect-nuget-inspector/detect-nuget-inspector.csproj
@@ -7,6 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
+    <InternalsVisibleTo Include="detect_nuget_inspector_tests" />
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Official docs for new .slnx file: https://devblogs.microsoft.com/dotnet/introducing-slnx-support-dotnet-cli/

It was rolled out March 2025, 	
→ Supported as of nuget 6.14: https://learn.microsoft.com/en-us/nuget/release-notes/nuget-6.14 (our compatibility matrix supports up to 6.8.1 right now)

Relates to this Detect PR: https://github.com/blackducksoftware/detect/pull/1688