### PR TITLE
Migrate Gradle distribution to internal Artifactory

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
+distributionUrl=https\://artifactory.tools.duckutil.net/artifactory/gradle-virtual/gradle-7.6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Moves the Gradle distribution download from the public Gradle website to the internal Artifactory server. Gradle version upgraded from 7.3.1 to 7.6.3 as 7.3.1 was not available on the internal server. 

**Change:**
- gradle-wrapper.properties — distributionUrl now points to artifactory.tools.duckutil.net/artifactory/gradle-virtual/                                                                                         
                                                                                                                                                                                                                 
**Investigated but not changed:**                                                                                                                                                                                  - build.gradle — fetches repository config from a shared script in integration-resources via GitHub. This is an accepted pattern shared across projects and was not changed in this PR.
- signing_util/Dockerfile — installs sig-macos-codesigning which is an internal package. The PYTHON_PYPI build arg controls the index URL and is expected to be passed by Jenkins at build time.
- No npm or Node.js code exists in this repository.